### PR TITLE
fix(docker): copy server dist to the proper location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN cd /app/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3 && \
     echo "SQLite3 production build complete"
 
 # Copy built server from builder
-COPY --from=server-builder /build/server/dist ./dist
+COPY --from=server-builder /build/server/dist ./server/dist
 
 # Copy built ui to static directory
 COPY --from=ui-builder /build/ui/dist ./static

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,4 +20,4 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 # Now running as resonance user - start the application
-exec node dist/server.js
+exec node server/dist/server.js


### PR DESCRIPTION
Fix #13 

The issue was due to the pnpm workspace enhancements made that caused the docker build to not copy the server dist directory to the correct location in the container.

This will copy the server dist into `./server/dist` in the container which contains the necessary node_modules.