### PR TITLE
fix(downloads): correct slskd enqueue response handling and add deferred status

### DIFF
--- a/server/src/models/DownloadTask.ts
+++ b/server/src/models/DownloadTask.ts
@@ -5,7 +5,7 @@ import { sequelize } from '@server/config/db/sequelize';
 /**
  * Status of a download task in the download workflow
  */
-export type DownloadTaskStatus = 'pending' | 'searching' | 'queued' | 'downloading' | 'completed' | 'failed';
+export type DownloadTaskStatus = 'pending' | 'searching' | 'deferred' | 'queued' | 'downloading' | 'completed' | 'failed';
 
 /**
  * Type of music item (album or track)

--- a/server/src/services/DownloadService.ts
+++ b/server/src/services/DownloadService.ts
@@ -41,9 +41,9 @@ export class DownloadService {
   }): Promise<{ items: ActiveDownload[]; total: number }> {
     const { limit = 50, offset = 0 } = params;
 
-    // Query database for active tasks (includes pending for retried items)
+    // Query database for active tasks (includes pending for retried items, deferred for timed-out searches)
     let { rows, count } = await DownloadTask.findAndCountAll({
-      where: { status: { [Op.in]: ['pending', 'searching', 'queued', 'downloading'] } },
+      where: { status: { [Op.in]: ['pending', 'searching', 'queued', 'downloading', 'deferred'] } },
       order: [['queuedAt', 'DESC']],
       limit,
       offset,
@@ -65,7 +65,7 @@ export class DownloadService {
 
       if (syncResult.activeSetChanged) {
         ({ rows, count } = await DownloadTask.findAndCountAll({
-          where: { status: { [Op.in]: ['pending', 'searching', 'queued', 'downloading'] } },
+          where: { status: { [Op.in]: ['pending', 'searching', 'queued', 'downloading', 'deferred'] } },
           order: [['queuedAt', 'DESC']],
           limit,
           offset,

--- a/server/src/types/downloads.ts
+++ b/server/src/types/downloads.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 export const downloadStatusSchema = z.enum([
   'pending',
   'searching',
+  'deferred',
   'queued',
   'downloading',
   'completed',

--- a/ui/src/components/downloads/ActiveDownloadsList.vue
+++ b/ui/src/components/downloads/ActiveDownloadsList.vue
@@ -21,6 +21,7 @@ const getStatusSeverity = (status: string) => {
     downloading: 'success',
     searching:   'info',
     queued:      'warning',
+    deferred:    'contrast',
     pending:     'secondary',
   };
 

--- a/ui/src/types/downloads.ts
+++ b/ui/src/types/downloads.ts
@@ -1,4 +1,4 @@
-export type DownloadStatus = 'pending' | 'searching' | 'queued' | 'downloading' | 'completed' | 'failed';
+export type DownloadStatus = 'pending' | 'searching' | 'queued' | 'downloading' | 'deferred' | 'completed' | 'failed';
 
 export interface DownloadProgress {
   filesCompleted:         number;


### PR DESCRIPTION
Fix #15
Fix #16 

## Summary
- Fixed SlskdClient.enqueue() to handle actual API response format (`{enqueued: [], failed: []}` arrays instead of counts)
- Added 'deferred' status for search operations that time out and can be retried later
- Trigger slskd download job immediately when queue items are approved for faster response

## Problem
The slskd API POST `/api/v0/transfers/downloads/{username}` returns:
```json
{
  "enqueued": [/* array of SlskdTransferFile objects */],
  "failed": [/* array of failed files */]
}
```

But the code expected `{Enqueued: number, Failed: number}`. This caused:
- `transferFiles.map is not a function` errors
- Downloads marked as failed even though they succeeded in slskd
- Missing file IDs in task metadata

## Changes
**SlskdClient.ts:**
- Updated `SlskdEnqueueResult` interface to use arrays of `SlskdTransferFile`
- Fixed response parsing to extract file IDs from returned transfer objects
- Improved logging to show actual enqueue/fail counts

**slskdDownloader.ts:**
- Handle array response correctly
- Check `enqueueResult.enqueued.length === 0` for failure case
- Extract file IDs from enqueued transfers
- Support reusing searches in 'deferred' state
- Better error logging with stack traces

**Download workflow:**
- Added 'deferred' status for searches that time out (can retry with same search ID)
- Include deferred tasks in active downloads query
- Auto-trigger slskd job when items are approved (QueueController)

**UI:**
- Added 'contrast' severity for deferred status badge

## Test Plan
- [x] Build succeeds (`pnpm run build`)
- [x] Approve queue item and verify download starts in slskd
- [x] Task status correctly shows 'queued' instead of 'failed'
- [x] File IDs are captured in task metadata
- [x] Logs show correct file counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)