### PR TITLE
chore: reduce socket progress log verbosity

### DIFF
--- a/server/src/config/logger.ts
+++ b/server/src/config/logger.ts
@@ -27,12 +27,18 @@ function parseBooleanEnv(value: string | undefined): boolean | undefined {
 }
 
 function normalizeLogLevel(value: string | undefined, fallback: LogLevel): LogLevel {
-  if (!value) return fallback;
+  if (!value) {
+    return fallback;
+  }
 
   const level = value.trim().toLowerCase();
 
-  if (level === 'warning') return 'warn';
-  if (level === 'err') return 'error';
+  if (level === 'warning') {
+    return 'warn';
+  }
+  if (level === 'err') {
+    return 'error';
+  }
 
   const allowed: Record<string, LogLevel> = {
     error:   'error',

--- a/server/src/plugins/io/namespaces/downloadsNamespace.ts
+++ b/server/src/plugins/io/namespaces/downloadsNamespace.ts
@@ -96,7 +96,7 @@ export function emitDownloadProgress(event: DownloadProgressEvent): void {
 
   try {
     namespaceInstance.emit('download:progress', event);
-    logger.debug(`[socket:downloads] Emitted download:progress for ${ event.id }`);
+    logger.silly(`[socket:downloads] Emitted download:progress for ${ event.id }`);
   } catch(error) {
     logger.error('[socket:downloads] Error emitting download:progress:', { error });
   }

--- a/server/src/plugins/io/namespaces/jobsNamespace.ts
+++ b/server/src/plugins/io/namespaces/jobsNamespace.ts
@@ -62,7 +62,7 @@ export function emitJobProgress(event: JobProgressEvent): void {
 
   try {
     namespaceInstance.emit('job:progress', event);
-    logger.debug(`[socket:jobs] Emitted job:progress for ${ event.name }: ${ event.message }`);
+    logger.silly(`[socket:jobs] Emitted job:progress for ${ event.name }: ${ event.message }`);
   } catch(error) {
     logger.error('[socket:jobs] Error emitting job:progress:', { error });
   }


### PR DESCRIPTION
## Summary
- Change `job:progress` and `download:progress` socket event logging from `debug` to `silly` level to reduce log noise
- Add braces to if statements in logger.ts for code style consistency

## Test plan
- [x] Verify logs are less noisy at `debug` level
- [x] Verify progress events still log at `silly` level when enabled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)