### PR TITLE
fix(preview): add album track selection for preview playback

### DIFF
--- a/server/src/controllers/PreviewController.ts
+++ b/server/src/controllers/PreviewController.ts
@@ -1,8 +1,8 @@
 import type { Request, Response } from 'express';
-import type { PreviewResponse } from '@server/types/preview';
+import type { PreviewResponse, AlbumPreviewResponse } from '@server/types/preview';
 
 import { BaseController } from '@server/controllers/BaseController';
-import { previewQuerySchema } from '@server/types/preview';
+import { previewQuerySchema, albumPreviewQuerySchema } from '@server/types/preview';
 import { sendValidationError } from '@server/utils/errorHandler';
 import { PreviewService } from '@server/services/PreviewService';
 
@@ -36,6 +36,26 @@ class PreviewController extends BaseController {
       return res.json(preview);
     } catch(error) {
       return this.handleError(res, error as Error, 'Failed to fetch preview');
+    }
+  };
+
+  /**
+   * Get preview URL for an album
+   * GET /api/v1/preview/album?artist=X&album=Y&mbid=Z&sourceTrack=W
+   */
+  getAlbumPreview = async(req: Request, res: Response): Promise<Response> => {
+    try {
+      const parseResult = albumPreviewQuerySchema.safeParse(req.query);
+
+      if (!parseResult.success) {
+        return sendValidationError(res, 'Invalid query parameters', { errors: parseResult.error.issues });
+      }
+
+      const preview: AlbumPreviewResponse = await this.previewService.getAlbumPreview(parseResult.data);
+
+      return res.json(preview);
+    } catch(error) {
+      return this.handleError(res, error as Error, 'Failed to fetch album preview');
     }
   };
 }

--- a/server/src/routes/api/v1/preview.ts
+++ b/server/src/routes/api/v1/preview.ts
@@ -5,5 +5,6 @@ import PreviewController from '@server/controllers/PreviewController';
 const router = Router();
 
 router.get('/', PreviewController.getPreview);
+router.get('/album', PreviewController.getAlbumPreview);
 
 export default router;

--- a/server/src/services/AlbumTrackSelector.test.ts
+++ b/server/src/services/AlbumTrackSelector.test.ts
@@ -1,0 +1,229 @@
+import {
+  describe, it, expect, beforeEach, afterEach, vi 
+} from 'vitest';
+import nock from 'nock';
+
+// Mock the config module before importing AlbumTrackSelector
+vi.mock('@server/config/settings', () => ({
+  getConfig: () => ({
+    preview: {
+      enabled: true,
+      spotify: {
+        enabled:       false,
+        client_id:     '',
+        client_secret: '',
+      },
+    },
+  }),
+  getDataPath: () => '/tmp',
+}));
+
+// Mock the logger to avoid file system operations
+vi.mock('@server/config/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info:  vi.fn(),
+    warn:  vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { AlbumTrackSelector } from './AlbumTrackSelector';
+
+describe('AlbumTrackSelector', () => {
+  let selector: AlbumTrackSelector;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    selector = new AlbumTrackSelector();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    selector.clearCache();
+  });
+
+  describe('selectTrack', () => {
+    it('uses sourceTrack when provided', async() => {
+      const result = await selector.selectTrack({
+        artist:      'Dream Theater',
+        album:       'Images and Words',
+        sourceTrack: 'Pull Me Under',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.title).toBe('Pull Me Under');
+      expect(result!.artist).toBe('Dream Theater');
+      expect(result!.previewUrl).toBeNull();
+      expect(result!.source).toBe('musicbrainz');
+    });
+
+    it('selects track from Deezer when sourceTrack not provided', async() => {
+      // Mock Deezer album search
+      nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'artist:"Dream Theater" album:"Images and Words"' })
+        .reply(200, {
+          data:  [{
+            id: 12345, title: 'Images and Words', artist: { id: 1, name: 'Dream Theater' } 
+          }],
+          total: 1,
+        });
+
+      // Mock Deezer album tracks
+      nock('https://api.deezer.com')
+        .get('/album/12345/tracks')
+        .reply(200, {
+          data: [
+            {
+              id: 1, title: 'Pull Me Under', preview: 'https://deezer.com/preview/1', artist: { id: 1, name: 'Dream Theater' }, duration: 300, track_position: 1 
+            },
+            {
+              id: 2, title: 'Another Day', preview: 'https://deezer.com/preview/2', artist: { id: 1, name: 'Dream Theater' }, duration: 240, track_position: 2 
+            },
+          ],
+          total: 2,
+        });
+
+      const result = await selector.selectTrack({
+        artist: 'Dream Theater',
+        album:  'Images and Words',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.title).toBe('Pull Me Under');
+      expect(result!.artist).toBe('Dream Theater');
+      expect(result!.previewUrl).toBe('https://deezer.com/preview/1');
+      expect(result!.source).toBe('deezer');
+    });
+
+    it('falls back to MusicBrainz when Deezer fails', async() => {
+      // Mock Deezer album search - not found
+      nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'artist:"Obscure Artist" album:"Rare Album"' })
+        .reply(200, { data: [], total: 0 });
+
+      nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'Obscure Artist Rare Album' })
+        .reply(200, { data: [], total: 0 });
+
+      // Mock MusicBrainz release lookup
+      nock('https://musicbrainz.org')
+        .get('/ws/2/release')
+        .query({
+          'release-group': 'abc123-mbid',
+          'limit':         1,
+          'fmt':           'json',
+        })
+        .reply(200, { releases: [{ id: 'release-id' }] });
+
+      nock('https://musicbrainz.org')
+        .get('/ws/2/release/release-id')
+        .query({ inc: 'recordings', fmt: 'json' })
+        .reply(200, {
+          media: [{
+            tracks: [
+              { title: 'Hidden Gem', position: 1 },
+              { title: 'Another Track', position: 2 },
+            ],
+          }],
+        });
+
+      const result = await selector.selectTrack({
+        artist: 'Obscure Artist',
+        album:  'Rare Album',
+        mbid:   'abc123-mbid',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.title).toBe('Hidden Gem');
+      expect(result!.source).toBe('musicbrainz');
+      expect(result!.previewUrl).toBeNull();
+    });
+
+    it('returns null when no track is found', async() => {
+      // Mock Deezer album search - not found
+      nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'artist:"Unknown Artist" album:"Unknown Album"' })
+        .reply(200, { data: [], total: 0 });
+
+      nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'Unknown Artist Unknown Album' })
+        .reply(200, { data: [], total: 0 });
+
+      const result = await selector.selectTrack({
+        artist: 'Unknown Artist',
+        album:  'Unknown Album',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('caches results', async() => {
+      // Mock Deezer album search
+      const deezerScope = nock('https://api.deezer.com')
+        .get('/search/album')
+        .query({ q: 'artist:"Cached Artist" album:"Cached Album"' })
+        .reply(200, {
+          data:  [{
+            id: 99999, title: 'Cached Album', artist: { id: 1, name: 'Cached Artist' } 
+          }],
+          total: 1,
+        });
+
+      // Mock Deezer album tracks
+      const tracksScope = nock('https://api.deezer.com')
+        .get('/album/99999/tracks')
+        .reply(200, {
+          data: [
+            {
+              id: 1, title: 'Cached Track', preview: 'https://deezer.com/cached', artist: { id: 1, name: 'Cached Artist' }, duration: 200, track_position: 1 
+            },
+          ],
+          total: 1,
+        });
+
+      // First call
+      const result1 = await selector.selectTrack({
+        artist: 'Cached Artist',
+        album:  'Cached Album',
+      });
+
+      // Second call (should be cached)
+      const result2 = await selector.selectTrack({
+        artist: 'Cached Artist',
+        album:  'Cached Album',
+      });
+
+      expect(result1).toEqual(result2);
+      expect(deezerScope.isDone()).toBe(true);
+      expect(tracksScope.isDone()).toBe(true);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('clears the cache', async() => {
+      // First call with sourceTrack
+      await selector.selectTrack({
+        artist:      'Test',
+        album:       'Test Album',
+        sourceTrack: 'Track 1',
+      });
+
+      selector.clearCache();
+
+      // After clearing, new call should work
+      const result = await selector.selectTrack({
+        artist:      'Test',
+        album:       'Test Album',
+        sourceTrack: 'Track 2',
+      });
+
+      expect(result!.title).toBe('Track 2');
+    });
+  });
+});

--- a/server/src/services/AlbumTrackSelector.ts
+++ b/server/src/services/AlbumTrackSelector.ts
@@ -1,0 +1,157 @@
+import { LRUCache } from 'lru-cache';
+import logger from '@server/config/logger';
+import { getConfig } from '@server/config/settings';
+import { DeezerClient } from './clients/DeezerClient';
+import { SpotifyClient } from './clients/SpotifyClient';
+import { MusicBrainzClient } from './clients/MusicBrainzClient';
+import type { SelectedAlbumTrack, AlbumPreviewQuery } from '@server/types/preview';
+
+interface CachedTrack {
+  track: SelectedAlbumTrack | null;
+}
+
+/**
+ * AlbumTrackSelector handles selecting the best track from an album for preview.
+ * Implements a fallback chain: sourceTrack -> Spotify -> Deezer -> MusicBrainz
+ * Uses LRU cache to avoid repeated API calls.
+ */
+export class AlbumTrackSelector {
+  private cache:             LRUCache<string, CachedTrack>;
+  private deezerClient:      DeezerClient;
+  private spotifyClient:     SpotifyClient | null = null;
+  private musicBrainzClient: MusicBrainzClient;
+
+  constructor() {
+    // LRU cache: 500 entries, 1-hour TTL
+    this.cache = new LRUCache<string, CachedTrack>({
+      max: 500,
+      ttl: 60 * 60 * 1000, // 1 hour
+    });
+
+    this.deezerClient = new DeezerClient();
+    this.musicBrainzClient = new MusicBrainzClient();
+
+    // Initialize Spotify client if configured
+    const config = getConfig();
+
+    if (config.preview?.spotify?.enabled && config.preview.spotify.client_id && config.preview.spotify.client_secret) {
+      this.spotifyClient = new SpotifyClient(
+        config.preview.spotify.client_id,
+        config.preview.spotify.client_secret
+      );
+      logger.debug('Spotify client initialized for album track selection');
+    }
+  }
+
+  /**
+   * Select the best track from an album for preview
+   */
+  async selectTrack(query: AlbumPreviewQuery): Promise<SelectedAlbumTrack | null> {
+    const {
+      artist, album, mbid, sourceTrack 
+    } = query;
+
+    const cacheKey = this.getCacheKey(artist, album);
+    const cached = this.cache.get(cacheKey);
+
+    if (cached !== undefined) {
+      logger.debug(`Album track cache hit for '${ artist } - ${ album }'`);
+
+      return cached.track;
+    }
+
+    let selectedTrack: SelectedAlbumTrack | null = null;
+
+    // 1. If sourceTrack is provided, use it directly
+    if (sourceTrack) {
+      logger.debug(`Using sourceTrack '${ sourceTrack }' for album '${ artist } - ${ album }'`);
+      selectedTrack = {
+        title:      sourceTrack,
+        artist,
+        previewUrl: null, // Will be resolved by PreviewService
+        source:     'musicbrainz', // Source is conceptually from MusicBrainz data
+      };
+      this.cache.set(cacheKey, { track: selectedTrack });
+
+      return selectedTrack;
+    }
+
+    // 2. Try Spotify if configured (provides popularity-sorted tracks)
+    if (this.spotifyClient) {
+      const spotifyTrack = await this.spotifyClient.getBestAlbumTrack(artist, album);
+
+      if (spotifyTrack) {
+        logger.debug(`Selected track from Spotify: '${ spotifyTrack.title }' for '${ artist } - ${ album }'`);
+        selectedTrack = {
+          title:      spotifyTrack.title,
+          artist,
+          previewUrl: spotifyTrack.previewUrl || null,
+          source:     'spotify',
+        };
+        this.cache.set(cacheKey, { track: selectedTrack });
+
+        return selectedTrack;
+      }
+    }
+
+    // 3. Try Deezer
+    const deezerTrack = await this.deezerClient.getAlbumTrack(artist, album);
+
+    if (deezerTrack) {
+      logger.debug(`Selected track from Deezer: '${ deezerTrack.title }' for '${ artist } - ${ album }'`);
+      selectedTrack = {
+        title:      deezerTrack.title,
+        artist,
+        previewUrl: deezerTrack.previewUrl || null,
+        source:     'deezer',
+      };
+      this.cache.set(cacheKey, { track: selectedTrack });
+
+      return selectedTrack;
+    }
+
+    // 4. Try MusicBrainz if MBID is provided
+    if (mbid) {
+      const tracks = await this.musicBrainzClient.getReleaseGroupTracks(mbid);
+
+      if (tracks.length > 0) {
+        // Use first track from the album
+        const firstTrack = tracks[0];
+
+        logger.debug(`Selected track from MusicBrainz: '${ firstTrack.title }' for '${ artist } - ${ album }'`);
+        selectedTrack = {
+          title:      firstTrack.title,
+          artist,
+          previewUrl: null, // MusicBrainz doesn't provide previews
+          source:     'musicbrainz',
+        };
+        this.cache.set(cacheKey, { track: selectedTrack });
+
+        return selectedTrack;
+      }
+    }
+
+    // Cache negative result to avoid repeated lookups
+    logger.debug(`No track found for album '${ artist } - ${ album }'`);
+    this.cache.set(cacheKey, { track: null });
+
+    return null;
+  }
+
+  /**
+   * Generate cache key from artist and album names
+   */
+  private getCacheKey(artist: string, album: string): string {
+    return `${ artist.toLowerCase() }:${ album.toLowerCase() }`;
+  }
+
+  /**
+   * Clear the album track cache
+   */
+  clearCache(): void {
+    this.cache.clear();
+    logger.debug('Album track selection cache cleared');
+  }
+}
+
+export default AlbumTrackSelector;

--- a/server/src/services/clients/DeezerClient.ts
+++ b/server/src/services/clients/DeezerClient.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import logger from '@server/config/logger';
-import type { DeezerSearchResponse, DeezerSearchResult } from '@server/types/preview';
+import type {
+  DeezerSearchResponse,
+  DeezerSearchResult,
+  DeezerAlbumSearchResponse,
+  DeezerAlbumTracksResponse,
+} from '@server/types/preview';
 
 const BASE_URL = 'https://api.deezer.com';
 
@@ -63,6 +68,101 @@ export class DeezerClient {
     const resultWithPreview = data.find((item) => item.preview && item.preview.length > 0);
 
     return resultWithPreview || null;
+  }
+
+  /**
+   * Search for an album and return its Deezer ID
+   */
+  async searchAlbum(artist: string, album: string): Promise<number | null> {
+    try {
+      // Try exact search first
+      const exactQuery = `artist:"${ artist }" album:"${ album }"`;
+      const response = await axios.get<DeezerAlbumSearchResponse>(`${ BASE_URL }/search/album`, {
+        params:  { q: exactQuery },
+        timeout: 10000,
+      });
+
+      const { data } = response.data;
+
+      if (data && data.length > 0) {
+        return data[0].id;
+      }
+
+      // Fallback to looser search
+      const looseQuery = `${ artist } ${ album }`;
+      const looseResponse = await axios.get<DeezerAlbumSearchResponse>(`${ BASE_URL }/search/album`, {
+        params:  { q: looseQuery },
+        timeout: 10000,
+      });
+
+      const looseData = looseResponse.data.data;
+
+      if (looseData && looseData.length > 0) {
+        return looseData[0].id;
+      }
+
+      return null;
+    } catch(error) {
+      if (axios.isAxiosError(error)) {
+        logger.debug(`Deezer album search failed for '${ artist } - ${ album }': ${ error.message }`);
+      } else {
+        logger.debug(`Deezer album search failed for '${ artist } - ${ album }': ${ String(error) }`);
+      }
+
+      return null;
+    }
+  }
+
+  /**
+   * Get tracks for an album
+   */
+  async getAlbumTracks(albumId: number): Promise<DeezerAlbumTracksResponse['data']> {
+    try {
+      const response = await axios.get<DeezerAlbumTracksResponse>(`${ BASE_URL }/album/${ albumId }/tracks`, { timeout: 10000 });
+
+      return response.data.data || [];
+    } catch(error) {
+      if (axios.isAxiosError(error)) {
+        logger.debug(`Deezer get album tracks failed for '${ albumId }': ${ error.message }`);
+      } else {
+        logger.debug(`Deezer get album tracks failed for '${ albumId }': ${ String(error) }`);
+      }
+
+      return [];
+    }
+  }
+
+  /**
+   * Get the best track from an album for preview (first track with preview URL)
+   */
+  async getAlbumTrack(artist: string, album: string): Promise<{ title: string; previewUrl: string } | null> {
+    const albumId = await this.searchAlbum(artist, album);
+
+    if (!albumId) {
+      return null;
+    }
+
+    const tracks = await this.getAlbumTracks(albumId);
+
+    // Find first track with a preview URL
+    const trackWithPreview = tracks.find((t) => t.preview && t.preview.length > 0);
+
+    if (trackWithPreview) {
+      return {
+        title:      trackWithPreview.title,
+        previewUrl: trackWithPreview.preview,
+      };
+    }
+
+    // If no preview found, return first track name (without preview)
+    if (tracks.length > 0) {
+      return {
+        title:      tracks[0].title,
+        previewUrl: '',
+      };
+    }
+
+    return null;
   }
 }
 

--- a/server/src/types/preview.ts
+++ b/server/src/types/preview.ts
@@ -11,12 +11,41 @@ export const previewQuerySchema = z.object({
 export type PreviewQuery = z.infer<typeof previewQuerySchema>;
 
 /**
+ * Zod schema for album preview query parameters
+ */
+export const albumPreviewQuerySchema = z.object({
+  artist:      z.string().min(1),
+  album:       z.string().min(1),
+  mbid:        z.string().optional(),
+  sourceTrack: z.string().optional(),
+});
+
+export type AlbumPreviewQuery = z.infer<typeof albumPreviewQuerySchema>;
+
+/**
  * Preview response
  */
 export interface PreviewResponse {
   url:       string | null;
   source:    'deezer' | 'spotify' | null;
   available: boolean;
+}
+
+/**
+ * Selected album track from track selection
+ */
+export interface SelectedAlbumTrack {
+  title:      string;
+  artist:     string;
+  previewUrl: string | null;
+  source:     'spotify' | 'deezer' | 'musicbrainz';
+}
+
+/**
+ * Album preview response (extends PreviewResponse with selected track info)
+ */
+export interface AlbumPreviewResponse extends PreviewResponse {
+  selectedTrack: string | null;
 }
 
 /**
@@ -59,4 +88,64 @@ export interface SpotifySearchResponse {
     items: SpotifyTrack[];
     total: number;
   };
+}
+
+export interface SpotifyAlbumSearchResponse {
+  albums: {
+    items: SpotifyAlbum[];
+    total: number;
+  };
+}
+
+export interface SpotifyAlbum {
+  id:           string;
+  name:         string;
+  artists:      { id: string; name: string }[];
+  images:       { url: string; width: number; height: number }[];
+  release_date: string;
+  total_tracks: number;
+}
+
+export interface SpotifyAlbumTrack {
+  id:           string;
+  name:         string;
+  preview_url:  string | null;
+  artists:      { id: string; name: string }[];
+  duration_ms:  number;
+  track_number: number;
+}
+
+export interface SpotifyAlbumTracksResponse {
+  items: SpotifyAlbumTrack[];
+  total: number;
+}
+
+/**
+ * Deezer album types
+ */
+export interface DeezerAlbumSearchResult {
+  id:            number;
+  title:         string;
+  artist:        { id: number; name: string };
+  cover_medium?: string;
+  nb_tracks:     number;
+}
+
+export interface DeezerAlbumSearchResponse {
+  data:  DeezerAlbumSearchResult[];
+  total: number;
+}
+
+export interface DeezerAlbumTrack {
+  id:             number;
+  title:          string;
+  preview:        string;
+  artist:         { id: number; name: string };
+  duration:       number;
+  track_position: number;
+}
+
+export interface DeezerAlbumTracksResponse {
+  data:  DeezerAlbumTrack[];
+  total: number;
 }

--- a/ui/src/services/preview.ts
+++ b/ui/src/services/preview.ts
@@ -1,4 +1,4 @@
-import type { PreviewResponse } from '@/types/player';
+import type { PreviewResponse, AlbumPreviewResponse } from '@/types/player';
 
 import client from './api';
 
@@ -7,8 +7,21 @@ export interface GetPreviewParams {
   track:  string;
 }
 
+export interface GetAlbumPreviewParams {
+  artist:       string;
+  album:        string;
+  mbid?:        string;
+  sourceTrack?: string;
+}
+
 export async function getPreview(params: GetPreviewParams): Promise<PreviewResponse> {
   const response = await client.get<PreviewResponse>('/preview', { params });
+
+  return response.data;
+}
+
+export async function getAlbumPreview(params: GetAlbumPreviewParams): Promise<AlbumPreviewResponse> {
+  const response = await client.get<AlbumPreviewResponse>('/preview/album', { params });
 
   return response.data;
 }

--- a/ui/src/types/player.ts
+++ b/ui/src/types/player.ts
@@ -1,17 +1,24 @@
 import type { QueueItem } from './queue';
 
 export interface PreviewTrack {
-  id:        string;
-  artist:    string;
-  title:     string;
-  album?:    string;
-  coverUrl?: string;
+  id:           string;
+  artist:       string;
+  title:        string;
+  album?:       string;
+  coverUrl?:    string;
+  type:         'album' | 'track';
+  mbid?:        string;
+  sourceTrack?: string;
 }
 
 export interface PreviewResponse {
   url:       string | null;
   source:    'deezer' | 'spotify' | null;
   available: boolean;
+}
+
+export interface AlbumPreviewResponse extends PreviewResponse {
+  selectedTrack: string | null;
 }
 
 export interface PlayerState {
@@ -31,10 +38,13 @@ export interface PlayerState {
  */
 export function queueItemToPreviewTrack(item: QueueItem): PreviewTrack {
   return {
-    id:       item.mbid,
-    artist:   item.artist,
-    title:    item.title || item.album || 'Unknown Track',
-    album:    item.album,
-    coverUrl: item.cover_url,
+    id:          item.mbid,
+    artist:      item.artist,
+    title:       item.title || item.album || 'Unknown Track',
+    album:       item.album,
+    coverUrl:    item.cover_url,
+    type:        item.type,
+    mbid:        item.mbid,
+    sourceTrack: item.source_track,
   };
 }


### PR DESCRIPTION
## Summary

- Adds server-side album track selection for preview playback
- When previewing albums, the system now selects an actual track from the album rather than using the album title as the track name
- Implements a fallback chain: sourceTrack → Spotify → Deezer → MusicBrainz
- Fixes audio error handling to prevent spurious error toasts when preview is unavailable

## Changes

### Server
- **New `AlbumTrackSelector` service** with LRU caching (500 entries, 1h TTL)
- **Extended API clients:**
  - `SpotifyClient`: `searchAlbum()`, `getAlbumTracks()`, `getBestAlbumTrack()`
  - `DeezerClient`: `searchAlbum()`, `getAlbumTracks()`, `getAlbumTrack()`
  - `MusicBrainzClient`: `getReleaseGroupTracks()`
- **New endpoint:** `GET /api/v1/preview/album?artist=X&album=Y&mbid=Z&sourceTrack=W`
- **Extended `PreviewService`** with `getAlbumPreview()` method

### UI
- Updated `PreviewTrack` type to include `type`, `mbid`, `sourceTrack`
- Added `getAlbumPreview()` API function
- Player store now detects album types and uses the album preview endpoint
- Fixed audio error event handling to prevent false "Audio Error" toasts

## Test plan
- [x] Run server tests: `pnpm --filter server test:run`
- [x] Build server: `pnpm --filter server build`
- [x] Build UI: `pnpm --filter ui build`
- [x] Manual testing: preview albums in the queue page
- [x] Verify warning toast appears when preview is unavailable
- [x] Verify no spurious "Audio Error" toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)