### PR TITLE
fix(server): add cover art fetching for ListenBrainz track mode

### DIFF
--- a/server/src/jobs/listenbrainzFetch.ts
+++ b/server/src/jobs/listenbrainzFetch.ts
@@ -94,6 +94,9 @@ export async function listenbrainzFetchJob(): Promise<void> {
           continue;
         }
 
+        // Get cover art URL if we have a release-group MBID
+        const coverUrl = trackInfo.releaseGroupMbid? coverClient.getCoverUrl(trackInfo.releaseGroupMbid): null;
+
         // Add to queue
         if (approvalMode === 'manual') {
           // Check if already in pending queue
@@ -104,12 +107,13 @@ export async function listenbrainzFetchJob(): Promise<void> {
           }
 
           await queueService.addPending({
-            artist: trackInfo.artist,
-            title:  trackInfo.title,
-            mbid:   trackInfo.mbid,
-            type:   'track',
-            score:  scorePercent,
-            source: 'listenbrainz',
+            artist:   trackInfo.artist,
+            title:    trackInfo.title,
+            mbid:     trackInfo.mbid,
+            type:     'track',
+            score:    scorePercent,
+            source:   'listenbrainz',
+            coverUrl: coverUrl || undefined,
           });
 
           logger.info(`  ? ${ trackInfo.artist } - ${ trackInfo.title } (pending approval)`);

--- a/server/src/services/clients/MusicBrainzClient.test.ts
+++ b/server/src/services/clients/MusicBrainzClient.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import nock from 'nock';
+
+import { MusicBrainzClient } from './MusicBrainzClient';
+
+describe('MusicBrainzClient', () => {
+  const client = new MusicBrainzClient();
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('resolveRecording', () => {
+    it('returns artist, title, mbid, and releaseGroupMbid', async() => {
+      const recordingMbid = 'test-recording-mbid';
+      const releaseGroupMbid = 'test-release-group-mbid';
+
+      nock('https://musicbrainz.org')
+        .get(`/ws/2/recording/${ recordingMbid }`)
+        .query({ inc: 'artists+releases+release-groups', fmt: 'json' })
+        .reply(200, {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [
+            {
+              'id':            'release-1',
+              'release-group': {
+                'id':           releaseGroupMbid,
+                'title':        'Test Album',
+                'primary-type': 'Album',
+              },
+            },
+          ],
+        });
+
+      const result = await client.resolveRecording(recordingMbid);
+
+      expect(result).toEqual({
+        artist:           'Test Artist',
+        title:            'Test Track',
+        mbid:             recordingMbid,
+        releaseGroupMbid: releaseGroupMbid,
+      });
+    });
+
+    it('prefers Album type over other release types', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      nock('https://musicbrainz.org')
+        .get(`/ws/2/recording/${ recordingMbid }`)
+        .query({ inc: 'artists+releases+release-groups', fmt: 'json' })
+        .reply(200, {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [
+            {
+              'id':            'single-release',
+              'release-group': {
+                'id':           'single-rg-mbid',
+                'title':        'Test Single',
+                'primary-type': 'Single',
+              },
+            },
+            {
+              'id':            'album-release',
+              'release-group': {
+                'id':           'album-rg-mbid',
+                'title':        'Test Album',
+                'primary-type': 'Album',
+              },
+            },
+          ],
+        });
+
+      const result = await client.resolveRecording(recordingMbid);
+
+      expect(result?.releaseGroupMbid).toBe('album-rg-mbid');
+    });
+
+    it('falls back to first release when no Album type exists', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      nock('https://musicbrainz.org')
+        .get(`/ws/2/recording/${ recordingMbid }`)
+        .query({ inc: 'artists+releases+release-groups', fmt: 'json' })
+        .reply(200, {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [
+            {
+              'id':            'ep-release',
+              'release-group': {
+                'id':           'ep-rg-mbid',
+                'title':        'Test EP',
+                'primary-type': 'EP',
+              },
+            },
+          ],
+        });
+
+      const result = await client.resolveRecording(recordingMbid);
+
+      expect(result?.releaseGroupMbid).toBe('ep-rg-mbid');
+    });
+
+    it('returns undefined releaseGroupMbid when no releases exist', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      nock('https://musicbrainz.org')
+        .get(`/ws/2/recording/${ recordingMbid }`)
+        .query({ inc: 'artists+releases+release-groups', fmt: 'json' })
+        .reply(200, {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [],
+        });
+
+      const result = await client.resolveRecording(recordingMbid);
+
+      expect(result).toEqual({
+        artist:           'Test Artist',
+        title:            'Test Track',
+        mbid:             recordingMbid,
+        releaseGroupMbid: undefined,
+      });
+    });
+
+    it('returns null on API error', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      nock('https://musicbrainz.org')
+        .get(`/ws/2/recording/${ recordingMbid }`)
+        .query({ inc: 'artists+releases+release-groups', fmt: 'json' })
+        .reply(404);
+
+      const result = await client.resolveRecording(recordingMbid);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/server/src/types/musicbrainz.ts
+++ b/server/src/types/musicbrainz.ts
@@ -10,9 +10,10 @@ export interface SearchResults<T> {
  * Recording info returned from resolveRecording
  */
 export interface RecordingInfo {
-  artist: string;
-  title:  string;
-  mbid:   string;
+  artist:            string;
+  title:             string;
+  mbid:              string;
+  releaseGroupMbid?: string;  // For cover art lookup
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes cover art not being fetched for ListenBrainz recommendations when using `mode: track`
- Enhances `resolveRecording()` to also return release-group MBID for cover art lookups
- Adds unit tests for the updated `MusicBrainzClient.resolveRecording()` method

## Root Cause
Track mode only called `resolveRecording()` which returned artist/title/mbid but no release-group information needed to fetch cover art from Cover Art Archive. Album mode worked correctly because it used `resolveRecordingToAlbum()` which includes release-group data.

## Changes
- `server/src/types/musicbrainz.ts`: Add `releaseGroupMbid` field to `RecordingInfo` type
- `server/src/services/clients/MusicBrainzClient.ts`: Update `resolveRecording()` to fetch release-group data, preferring Album releases over Singles/EPs
- `server/src/jobs/listenbrainzFetch.ts`: Use release-group MBID to get cover URL in track mode
- `server/src/services/clients/MusicBrainzClient.test.ts`: Add 5 tests for the updated method

## Test plan
- [x] All 96 tests pass (91 existing + 5 new)
- [x] Lint passes with no warnings
- [x] Manual test: Run app with `mode: track`, trigger `POST /api/v1/actions/lb-fetch`, verify queue items show cover art

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)