### PR TITLE
fix: weekly playlist identifier to use title

### DIFF
--- a/server/src/services/clients/ListenBrainzClient.ts
+++ b/server/src/services/clients/ListenBrainzClient.ts
@@ -111,7 +111,7 @@ export class ListenBrainzClient {
   async findWeeklyExplorationPlaylist(username: string): Promise<ListenBrainzPlaylistMetadata | null> {
     const playlists = await this.fetchPlaylistsCreatedFor(username);
 
-    const weeklyPlaylist = playlists.find((p) => p.identifier.includes('weekly-exploration'));
+    const weeklyPlaylist = playlists.find((p) => p.title.toLowerCase().includes('weekly exploration'));
 
     return weeklyPlaylist || null;
   }


### PR DESCRIPTION
Related #25 

There was an issue with how we were  searching for `'weekly-exploration'` in the `identifier` field (which is just a URL with a UUID like `https://listenbrainz.org/playlist/<uuid>`), but it should be searching in the `title` field which contains text like `'Weekly Exploration for {user}, week of 2026-01-19 Mon'`.