### PR TITLE
feat: add multi-auth support with mode-aware login UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,20 +218,27 @@ The web UI provides:
 
 ## Authentication
 
-### Built-in Auth
+Resonance supports multiple authentication modes:
 
-Resonance includes built-in authentication options:
+| Mode | Config | Login UI | Use Case |
+|------|--------|----------|----------|
+| Basic | `type: "basic"` | Username + Password | Simple setup |
+| API Key | `type: "api_key"` | API Key field | Programmatic access |
+| Proxy | `type: "proxy"` | Auto-redirect | External auth (Authelia) |
+| Disabled | `enabled: false` | Auto-redirect | Development/trusted networks |
+
+### Basic Auth
 
 ```yaml
 ui:
   auth:
     enabled: true
-    type: "basic"        # HTTP Basic Auth
+    type: "basic"
     username: "admin"
     password: "secure_password"
 ```
 
-Or use API key authentication:
+### API Key Auth
 
 ```yaml
 ui:
@@ -241,15 +248,26 @@ ui:
     api_key: "your_secret_api_key"
 ```
 
-### Authelia Integration
+### Proxy Auth (Authelia, etc.)
 
-For advanced authentication (SSO, 2FA, LDAP), integrate with [Authelia](https://www.authelia.com/) via your reverse proxy. See [docs/authelia-integration.md](docs/authelia-integration.md).
+For SSO, 2FA, or LDAP integration, use proxy mode with a reverse proxy:
+
+```yaml
+ui:
+  auth:
+    enabled: true
+    type: "proxy"
+```
+
+See [docs/authelia-integration.md](docs/authelia-integration.md) for setup instructions.
 
 ## API
 
 Resonance exposes a REST API for automation and integration:
 
 ```
+GET  /api/v1/auth/info          # Get auth configuration (public)
+GET  /api/v1/auth/me            # Get current user info
 GET  /api/v1/queue/pending      # List pending items
 POST /api/v1/queue/approve      # Approve items
 POST /api/v1/queue/reject       # Reject items

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,44 @@ Health check endpoint (no auth required).
 
 ---
 
+### Auth
+
+#### GET /api/v1/auth/info
+
+Get authentication configuration (no auth required).
+
+**Response:**
+```json
+{
+  "enabled": true,
+  "type": "basic"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Whether authentication is enabled |
+| `type` | string | Auth type: `basic`, `api_key`, `proxy`, or `disabled` |
+
+#### GET /api/v1/auth/me
+
+Get current authenticated user info (requires auth).
+
+**Response:**
+```json
+{
+  "username": "admin"
+}
+```
+
+Username returned varies by auth mode:
+- `basic`: Configured username from config
+- `api_key`: "API User"
+- `proxy`: Value of `Remote-User` header
+- `disabled`: "Guest"
+
+---
+
 ### Queue Management
 
 #### GET /api/v1/queue/pending

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,10 +282,11 @@ Simple JSON arrays of identifiers (MBIDs or entry strings).
 
 ### Built-in Authentication
 
-Two options:
+Three options:
 
-1. **HTTP Basic Auth** - Username/password in config
-2. **API Key Auth** - Bearer token in header
+1. **HTTP Basic Auth** - Username/password login form
+2. **API Key Auth** - Bearer token login form
+3. **Proxy Auth** - Delegates to external auth (Authelia, etc.), auto-redirects users
 
 ### Authelia Integration
 

--- a/docs/authelia-integration.md
+++ b/docs/authelia-integration.md
@@ -55,6 +55,11 @@ ui:
       - "Remote-Groups"
 ```
 
+**Note:** When `type: "proxy"` is set, the Resonance UI will:
+1. Detect the auth mode via `/api/v1/auth/info`
+2. Skip the login form and auto-redirect to the dashboard
+3. Display the username from the `Remote-User` header (set by Authelia)
+
 ## Caddy Configuration
 
 ### Basic Forward Auth Setup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -471,6 +471,17 @@ The preview player uses Deezer by default (no API key required). Spotify can be 
 *Required if `type: basic`
 **Required if `type: api_key`
 
+**Auth Mode Behaviors:**
+
+| Mode | Login UI | API Header | Username Source |
+|------|----------|------------|-----------------|
+| `basic` | Username + Password form | `Authorization: Basic <credentials>` | Config `username` |
+| `api_key` | API Key input field | `Authorization: Bearer <token>` | "API User" |
+| `proxy` | Auto-redirect (no login) | None (proxy handles auth) | `Remote-User` header |
+| `disabled` | Auto-redirect (no login) | None | "Guest" |
+
+When `enabled: false`, the UI behaves the same as `proxy` mode - users are automatically authenticated and redirected to the dashboard.
+
 ## Minimal Configuration
 
 The bare minimum to run Resonance with ListenBrainz only:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -228,12 +228,21 @@ ui:
     enabled: true
 
     # Auth type: "basic", "api_key", or "proxy"
-    # Use "proxy" if using external auth (Authelia, etc.)
     type: "basic"
 
-    # For type: "basic" - HTTP Basic Authentication
+    # --- Option 1: Basic Auth (username/password login form) ---
+    # type: "basic"
     username: "admin"
     password: "changeme"  # CHANGE THIS!
 
-    # For type: "api_key" - Bearer token authentication
+    # --- Option 2: API Key Auth (API key login form) ---
+    # type: "api_key"
     # api_key: "your_secret_api_key"
+
+    # --- Option 3: Proxy Auth (external auth via Authelia, etc.) ---
+    # type: "proxy"
+    # No additional config needed - relies on Remote-User header from proxy
+
+    # --- Option 4: Disabled Auth ---
+    # enabled: false
+    # All users treated as "Guest", no login required

--- a/server/src/controllers/AuthController.test.ts
+++ b/server/src/controllers/AuthController.test.ts
@@ -1,0 +1,178 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach 
+} from 'vitest';
+import type { Request, Response } from 'express';
+
+// Mock getConfig while preserving other exports
+vi.mock('@server/config/settings', async(importOriginal) => {
+  const actual = await importOriginal<typeof import('@server/config/settings')>();
+
+  return {
+    ...actual,
+    getConfig: vi.fn(),
+  };
+});
+
+import { getConfig } from '@server/config/settings';
+import AuthController from './AuthController';
+
+const mockGetConfig = vi.mocked(getConfig);
+
+function createMockResponse(): Response {
+  const res = { json: vi.fn().mockReturnThis() } as unknown as Response;
+
+  return res;
+}
+
+function createMockRequest(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+describe('AuthController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('getInfo', () => {
+    it('returns disabled when auth is not enabled', () => {
+      mockGetConfig.mockReturnValue({ ui: { auth: { enabled: false, type: 'basic' } } } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getInfo(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        enabled: false,
+        type:    'disabled',
+      });
+    });
+
+    it('returns basic auth type when enabled with basic', () => {
+      mockGetConfig.mockReturnValue({
+        ui: {
+          auth: {
+            enabled: true, type: 'basic', username: 'admin', password: 'secret' 
+          } 
+        }, 
+      } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getInfo(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        enabled: true,
+        type:    'basic',
+      });
+    });
+
+    it('returns api_key auth type when enabled with api_key', () => {
+      mockGetConfig.mockReturnValue({
+        ui: {
+          auth: {
+            enabled: true, type: 'api_key', api_key: 'secret-key' 
+          } 
+        }, 
+      } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getInfo(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        enabled: true,
+        type:    'api_key',
+      });
+    });
+
+    it('returns proxy auth type when enabled with proxy', () => {
+      mockGetConfig.mockReturnValue({ ui: { auth: { enabled: true, type: 'proxy' } } } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getInfo(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        enabled: true,
+        type:    'proxy',
+      });
+    });
+  });
+
+  describe('getMe', () => {
+    it('returns Guest when auth is disabled', () => {
+      mockGetConfig.mockReturnValue({ ui: { auth: { enabled: false, type: 'basic' } } } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getMe(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ username: 'Guest' });
+    });
+
+    it('returns configured username for basic auth', () => {
+      mockGetConfig.mockReturnValue({
+        ui: {
+          auth: {
+            enabled: true, type: 'basic', username: 'admin', password: 'secret' 
+          } 
+        }, 
+      } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getMe(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ username: 'admin' });
+    });
+
+    it('returns API User for api_key auth', () => {
+      mockGetConfig.mockReturnValue({
+        ui: {
+          auth: {
+            enabled: true, type: 'api_key', api_key: 'secret-key' 
+          } 
+        }, 
+      } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getMe(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ username: 'API User' });
+    });
+
+    it('returns Remote-User header value for proxy auth', () => {
+      mockGetConfig.mockReturnValue({ ui: { auth: { enabled: true, type: 'proxy' } } } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest({ 'remote-user': 'john.doe' });
+      const res = createMockResponse();
+
+      AuthController.getMe(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ username: 'john.doe' });
+    });
+
+    it('returns Proxy User when Remote-User header is missing for proxy auth', () => {
+      mockGetConfig.mockReturnValue({ ui: { auth: { enabled: true, type: 'proxy' } } } as ReturnType<typeof getConfig>);
+
+      const req = createMockRequest();
+      const res = createMockResponse();
+
+      AuthController.getMe(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ username: 'Proxy User' });
+    });
+  });
+});

--- a/server/src/controllers/AuthController.ts
+++ b/server/src/controllers/AuthController.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from 'express';
+import type { AuthInfoResponse, AuthMeResponse } from '@server/types/responses';
+
+import { BaseController } from '@server/controllers/BaseController';
+import { getConfig } from '@server/config/settings';
+
+/**
+ * Auth controller for authentication info endpoints
+ */
+class AuthController extends BaseController {
+  /**
+   * Get auth configuration (public - no secrets)
+   * GET /api/v1/auth/info
+   */
+  getInfo = (_req: Request, res: Response): Response => {
+    const config = getConfig();
+    const authSettings = config.ui?.auth;
+
+    const response: AuthInfoResponse = {
+      enabled: authSettings?.enabled ?? false,
+      type:    authSettings?.enabled ? authSettings.type : 'disabled',
+    };
+
+    return res.json(response);
+  };
+
+  /**
+   * Get current authenticated user info
+   * GET /api/v1/auth/me
+   */
+  getMe = (req: Request, res: Response): Response => {
+    const config = getConfig();
+    const authSettings = config.ui?.auth;
+
+    let username = 'Guest';
+
+    if (!authSettings?.enabled) {
+      username = 'Guest';
+    } else {
+      switch (authSettings.type) {
+        case 'basic':
+          username = authSettings.username || 'User';
+          break;
+
+        case 'api_key':
+          username = 'API User';
+          break;
+
+        case 'proxy':
+          username = (req.headers['remote-user'] as string) || 'Proxy User';
+          break;
+      }
+    }
+
+    const response: AuthMeResponse = { username };
+
+    return res.json(response);
+  };
+}
+
+export default new AuthController();

--- a/server/src/plugins/app.ts
+++ b/server/src/plugins/app.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import logger from '@server/config/logger';
 import { authMiddleware } from '@server/middleware/auth';
 import healthRoutes from '@server/routes/api/v1/health';
+import authRoutes from '@server/routes/api/v1/auth';
 import queueRoutes from '@server/routes/api/v1/queue';
 import jobsRoutes from '@server/routes/api/v1/jobs';
 import searchRoutes from '@server/routes/api/v1/search';
@@ -13,6 +14,7 @@ import wishlistRoutes from '@server/routes/api/v1/wishlist';
 import downloadsRoutes from '@server/routes/api/v1/downloads';
 import libraryRoutes from '@server/routes/api/v1/library';
 import previewRoutes from '@server/routes/api/v1/preview';
+import AuthController from '@server/controllers/AuthController';
 
 const app = express();
 
@@ -29,13 +31,15 @@ app.use(
 // JSON body parser
 app.use(express.json());
 
-// Health check route (no auth required)
+// Public routes (no auth required)
 app.use('/health', healthRoutes);
+app.get('/api/v1/auth/info', AuthController.getInfo);
 
 // Apply auth middleware to all /api/* routes
 app.use('/api', authMiddleware);
 
 // API routes
+app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/queue', queueRoutes);
 app.use('/api/v1/jobs', jobsRoutes);
 app.use('/api/v1/search', searchRoutes);

--- a/server/src/routes/api/v1/auth.ts
+++ b/server/src/routes/api/v1/auth.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+import AuthController from '@server/controllers/AuthController';
+
+const router = Router();
+
+// Protected endpoint - requires auth
+// Note: /info is registered directly in app.ts before auth middleware
+router.get('/me', AuthController.getMe);
+
+export default router;

--- a/server/src/types/responses.ts
+++ b/server/src/types/responses.ts
@@ -52,3 +52,20 @@ export const healthResponseSchema = z.object({
 });
 
 export type HealthResponse = z.infer<typeof healthResponseSchema>;
+
+/**
+ * Auth info response schema (public - no secrets)
+ */
+export const authInfoResponseSchema = z.object({
+  enabled: z.boolean(),
+  type:    z.enum(['basic', 'api_key', 'proxy', 'disabled']),
+});
+
+export type AuthInfoResponse = z.infer<typeof authInfoResponseSchema>;
+
+/**
+ * Auth current user response schema
+ */
+export const authMeResponseSchema = z.object({ username: z.string() });
+
+export type AuthMeResponse = z.infer<typeof authMeResponseSchema>;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,6 +19,7 @@ const router = useRouter();
 const { sidebarTopItems, sidebarBottomItems } = useSidebarItems();
 
 const isAuthed = computed(() => authStore.isAuthenticated);
+const requiresLogin = computed(() => authStore.requiresLogin);
 
 function handleLogout(): void {
   authStore.logout();
@@ -54,7 +55,7 @@ function handleLogout(): void {
 
     <template #header-right>
       <Button
-        v-if="isAuthed"
+        v-if="requiresLogin && isAuthed"
         appearance="secondary"
         size="small"
         @click="handleLogout"

--- a/ui/src/composables/useAuth.ts
+++ b/ui/src/composables/useAuth.ts
@@ -9,9 +9,12 @@ export function useAuth() {
 
   const isAuthenticated = computed(() => store.isAuthenticated);
   const username = computed(() => store.username);
+  const authMode = computed(() => store.authMode);
+  const authConfig = computed(() => store.authConfig);
+  const requiresLogin = computed(() => store.requiresLogin);
 
-  async function login(user: string, password: string) {
-    const success = await store.login(user, password);
+  async function login(userOrKey: string, password?: string) {
+    const success = await store.login(userOrKey, password);
 
     if (success) {
       await router.push(ROUTE_PATHS.DASHBOARD);
@@ -28,6 +31,9 @@ export function useAuth() {
   return {
     isAuthenticated,
     username,
+    authMode,
+    authConfig,
+    requiresLogin,
     login,
     logout,
   };

--- a/ui/src/pages/public/LoginPage.vue
+++ b/ui/src/pages/public/LoginPage.vue
@@ -1,28 +1,79 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import Card from 'primevue/card';
 import InputText from 'primevue/inputtext';
 import Password from 'primevue/password';
 import Button from 'primevue/button';
 import Message from 'primevue/message';
-import { useAuth } from '@/composables/useAuth';
+import ProgressSpinner from 'primevue/progressspinner';
+import { useAuthStore } from '@/stores/auth';
+import { ROUTE_PATHS } from '@/constants/routes';
 
-const { login } = useAuth();
+const store = useAuthStore();
+const router = useRouter();
 
 const username = ref('');
 const password = ref('');
+const apiKey = ref('');
 const error = ref('');
 const loading = ref(false);
+const configLoading = ref(true);
 
-async function handleSubmit() {
+const authMode = computed(() => store.authMode);
+const showBasicForm = computed(() => authMode.value === 'basic');
+const showApiKeyForm = computed(() => authMode.value === 'api_key');
+const showAutoAuth = computed(() => authMode.value === 'proxy' || authMode.value === 'disabled');
+
+onMounted(async() => {
+  try {
+    await store.loadAuthConfig();
+
+    // For proxy/disabled modes, auto-authenticate and redirect
+    if (showAutoAuth.value) {
+      await store.initialize();
+
+      if (store.isAuthenticated) {
+        await router.replace(ROUTE_PATHS.DASHBOARD);
+      }
+    }
+  } catch {
+    error.value = 'Failed to load authentication configuration';
+  } finally {
+    configLoading.value = false;
+  }
+});
+
+async function handleBasicSubmit() {
   error.value = '';
   loading.value = true;
 
   try {
-    const success = await login(username.value, password.value);
+    const success = await store.loginBasic(username.value, password.value);
 
-    if (!success) {
+    if (success) {
+      await router.push(ROUTE_PATHS.DASHBOARD);
+    } else {
       error.value = 'Invalid username or password';
+    }
+  } catch {
+    error.value = 'An error occurred. Please try again.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleApiKeySubmit() {
+  error.value = '';
+  loading.value = true;
+
+  try {
+    const success = await store.loginApiKey(apiKey.value);
+
+    if (success) {
+      await router.push(ROUTE_PATHS.DASHBOARD);
+    } else {
+      error.value = 'Invalid API key';
     }
   } catch {
     error.value = 'An error occurred. Please try again.';
@@ -50,11 +101,30 @@ async function handleSubmit() {
         <p class="mt-2 text-muted">Sign in to manage your music queue</p>
       </div>
 
-      <!-- Login Form -->
-      <Card>
+      <Card v-if="configLoading">
         <template #content>
-          <form @submit.prevent="handleSubmit" class="flex flex-column gap-4">
-            <!-- Error Message -->
+          <div class="flex flex-column align-items-center gap-3 py-4">
+            <ProgressSpinner style="width: 40px; height: 40px" />
+          </div>
+        </template>
+      </Card>
+
+      <!-- Auto-auth message (proxy/disabled) -->
+      <Card v-else-if="showAutoAuth">
+        <template #content>
+          <div class="flex flex-column align-items-center gap-3 py-4">
+            <ProgressSpinner style="width: 40px; height: 40px" />
+            <span class="text-muted">
+              {{ authMode === 'proxy' ? 'Authenticating via proxy...' : 'Authentication disabled, redirecting...' }}
+            </span>
+          </div>
+        </template>
+      </Card>
+
+      <!-- Basic Auth Form -->
+      <Card v-else-if="showBasicForm">
+        <template #content>
+          <form @submit.prevent="handleBasicSubmit" class="flex flex-column gap-4">
             <Message v-if="error" severity="error" :closable="false">
               {{ error }}
             </Message>
@@ -87,6 +157,37 @@ async function handleSubmit() {
             </div>
 
             <!-- Submit Button -->
+            <Button
+              type="submit"
+              label="Sign In"
+              :loading="loading"
+              class="w-full"
+            />
+          </form>
+        </template>
+      </Card>
+
+      <!-- API Key Form -->
+      <Card v-else-if="showApiKeyForm">
+        <template #content>
+          <form @submit.prevent="handleApiKeySubmit" class="flex flex-column gap-4">
+            <Message v-if="error" severity="error" :closable="false">
+              {{ error }}
+            </Message>
+
+            <div class="flex flex-column gap-2">
+              <label for="apiKey" class="text-sm font-medium">API Key</label>
+              <Password
+                id="apiKey"
+                v-model="apiKey"
+                required
+                autocomplete="off"
+                placeholder="Enter your API key"
+                :feedback="false"
+                toggle-mask
+              />
+            </div>
+
             <Button
               type="submit"
               label="Sign In"

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -8,11 +8,25 @@ const router = createRouter({
   routes
 });
 
-router.beforeEach((to, _from, next) => {
+router.beforeEach(async(to, _from, next) => {
   const authStore = useAuthStore();
 
+  // Ensure auth config is loaded before first navigation
+  if (!authStore.configLoaded) {
+    await authStore.initialize();
+  }
+
+  // For proxy/disabled modes, treat as always authenticated
+  const requiresLogin = authStore.requiresLogin;
+
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
-    next({ name: 'login' });
+    // Only redirect to login if login is actually required
+    if (requiresLogin) {
+      next({ name: 'login' });
+    } else {
+      // For proxy/disabled, allow through
+      next();
+    }
   } else if (to.name === 'login' && authStore.isAuthenticated) {
     next({ name: 'dashboard' });
   } else {

--- a/ui/src/services/auth.ts
+++ b/ui/src/services/auth.ts
@@ -1,0 +1,25 @@
+import type { AuthConfig, AuthUser } from '@/types/auth';
+
+import axios from 'axios';
+
+// Use raw axios instance without interceptors for public endpoint
+const baseURL = import.meta.env.VITE_API_URL || '/api/v1';
+
+/**
+ * Fetch auth configuration from server (public endpoint)
+ */
+export async function fetchAuthConfig(): Promise<AuthConfig> {
+  const response = await axios.get<AuthConfig>(`${ baseURL }/auth/info`);
+
+  return response.data;
+}
+
+/**
+ * Fetch current user info (requires auth)
+ * Uses provided credentials/headers for authentication
+ */
+export async function fetchCurrentUser(headers?: Record<string, string>): Promise<AuthUser> {
+  const response = await axios.get<AuthUser>(`${ baseURL }/auth/me`, { headers });
+
+  return response.data;
+}

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -1,26 +1,111 @@
+import type { AuthConfig, AuthMode } from '@/types/auth';
+
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+
+import { fetchAuthConfig, fetchCurrentUser } from '@/services/auth';
 import client from '@/services/api';
 
 export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = ref(false);
   const username = ref<string | null>(null);
+  const authConfig = ref<AuthConfig | null>(null);
+  const configLoaded = ref(false);
 
-  function initialize() {
-    const storedUsername = localStorage.getItem('auth_username');
-    const storedCredentials = localStorage.getItem('auth_credentials');
+  const requiresLogin = computed(() => {
+    if (!authConfig.value) {
+      return true;
+    }
+    if (!authConfig.value.enabled) {
+      return false;
+    }
 
-    if (storedUsername && storedCredentials) {
-      isAuthenticated.value = true;
-      username.value = storedUsername;
+    return authConfig.value.type === 'basic' || authConfig.value.type === 'api_key';
+  });
+
+  const authMode = computed<AuthMode>(() => {
+    if (!authConfig.value?.enabled) {
+      return 'disabled';
+    }
+
+    return authConfig.value.type;
+  });
+
+  async function loadAuthConfig(): Promise<AuthConfig> {
+    try {
+      authConfig.value = await fetchAuthConfig();
+      configLoaded.value = true;
+      // Store auth mode for API service to use
+      localStorage.setItem('auth_mode', authConfig.value.enabled ? authConfig.value.type : 'disabled');
+
+      return authConfig.value;
+    } catch {
+      // Default to basic auth if config fetch fails
+      authConfig.value = { enabled: true, type: 'basic' };
+      configLoaded.value = true;
+      localStorage.setItem('auth_mode', 'basic');
+
+      return authConfig.value;
     }
   }
 
-  async function login(user: string, password: string): Promise<boolean> {
+  async function initialize(): Promise<void> {
+    await loadAuthConfig();
+
+    if (!authConfig.value?.enabled || authConfig.value.type === 'proxy') {
+      await autoAuthenticate();
+
+      return;
+    }
+
+    if (authConfig.value.type === 'basic') {
+      const storedUsername = localStorage.getItem('auth_username');
+      const storedCredentials = localStorage.getItem('auth_credentials');
+
+      if (storedUsername && storedCredentials) {
+        isAuthenticated.value = true;
+        username.value = storedUsername;
+      }
+    } else if (authConfig.value.type === 'api_key') {
+      const storedApiKey = localStorage.getItem('auth_api_key');
+
+      if (storedApiKey) {
+        // Verify the API key is still valid
+        try {
+          const user = await fetchCurrentUser({ Authorization: `Bearer ${ storedApiKey }` });
+
+          isAuthenticated.value = true;
+          username.value = user.username;
+        } catch {
+          // API key is invalid, clear it
+          localStorage.removeItem('auth_api_key');
+        }
+      }
+    }
+  }
+
+  /**
+   * Auto-authenticate for disabled/proxy modes
+   */
+  async function autoAuthenticate(): Promise<void> {
+    try {
+      const user = await fetchCurrentUser();
+
+      isAuthenticated.value = true;
+      username.value = user.username;
+    } catch {
+      // For disabled mode, still mark as authenticated
+      if (!authConfig.value?.enabled) {
+        isAuthenticated.value = true;
+        username.value = 'Guest';
+      }
+    }
+  }
+
+  async function loginBasic(user: string, password: string): Promise<boolean> {
     const credentials = btoa(`${ user }:${ password }`);
 
     try {
-      // Test credentials by making a request
       const response = await client.get('/queue/pending', {
         params:  { limit: 1 },
         headers: { Authorization: `Basic ${ credentials }` },
@@ -41,9 +126,36 @@ export const useAuthStore = defineStore('auth', () => {
     return false;
   }
 
-  function logout() {
+
+  async function loginApiKey(apiKey: string): Promise<boolean> {
+    try {
+      const user = await fetchCurrentUser({ Authorization: `Bearer ${ apiKey }` });
+
+      localStorage.setItem('auth_api_key', apiKey);
+      isAuthenticated.value = true;
+      username.value = user.username;
+
+      return true;
+    } catch {
+      // Authentication failed
+    }
+
+    return false;
+  }
+
+  async function login(userOrKey: string, password?: string): Promise<boolean> {
+    if (authConfig.value?.type === 'api_key') {
+      return loginApiKey(userOrKey);
+    }
+
+    // Default to basic
+    return loginBasic(userOrKey, password || '');
+  }
+
+  function logout(): void {
     localStorage.removeItem('auth_credentials');
     localStorage.removeItem('auth_username');
+    localStorage.removeItem('auth_api_key');
     isAuthenticated.value = false;
     username.value = null;
   }
@@ -51,8 +163,17 @@ export const useAuthStore = defineStore('auth', () => {
   return {
     isAuthenticated,
     username,
+    authConfig,
+    configLoaded,
+
+    requiresLogin,
+    authMode,
+
     initialize,
+    loadAuthConfig,
     login,
+    loginBasic,
+    loginApiKey,
     logout,
   };
 });

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -1,3 +1,14 @@
+export type AuthMode = 'basic' | 'api_key' | 'proxy' | 'disabled';
+
+export interface AuthConfig {
+  enabled: boolean;
+  type:    AuthMode;
+}
+
+export interface AuthUser {
+  username: string;
+}
+
 export interface AuthCredentials {
   username: string;
   password: string;
@@ -6,4 +17,5 @@ export interface AuthCredentials {
 export interface AuthState {
   isAuthenticated: boolean;
   username:        string | null;
+  authConfig:      AuthConfig | null;
 }


### PR DESCRIPTION
## Summary

- Add support for all 4 authentication modes (`basic`, `api_key`, `proxy`, `disabled`) with mode-aware UI behavior
- Add new API endpoints: `GET /api/v1/auth/info` (public) and `GET /api/v1/auth/me`
- UI automatically detects auth mode and shows appropriate login form or auto-redirects
- Comprehensive documentation updates for the new multi-auth feature

## Changes

### Server
- Add `/api/v1/auth/info` endpoint to get auth configuration (no auth required)
- Add `/api/v1/auth/me` endpoint to get current user info
- Add `AuthController` with comprehensive test coverage

### UI
- `LoginPage` detects auth mode via `/api/v1/auth/info` and shows appropriate form
- Auto-redirect to dashboard for `proxy` and `disabled` modes
- Router guards handle mode-aware navigation

### Documentation
- Add Auth endpoints section to `docs/api.md`
- Add auth mode behaviors table to `docs/configuration.md`
- Update `docs/architecture.md` with 3 built-in auth options
- Add proxy mode UI behavior note to `docs/authelia-integration.md`
- Expand `examples/config.yaml` with all 4 auth mode examples
- Update `README.md` Authentication section with modes table and examples

## Test plan

- [x] Verify `basic` auth mode shows username/password form
- [x] Verify `api_key` auth mode shows API key input field
- [x] Verify `proxy` auth mode auto-redirects to dashboard
- [x] Verify `disabled` auth mode auto-redirects to dashboard as "Guest"
- [x] Run server tests: `pnpm --filter server test:run`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)