### PR TITLE
refactor: rename project from Resonance to DeepCrate

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -38,7 +38,7 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request for the Resonance music discovery application.
+            Review this pull request for the DeepCrate music discovery application.
 
             ## Code Quality Review
             - TypeScript best practices and type safety

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,13 @@ pnpm run build         # Production build to dist/
 
 ### Docker
 ```bash
-docker build -t resonance .
-docker run -v ./config.yaml:/config/config.yaml -v ./data:/data -p 8080:8080 resonance
+docker build -t deepcrate .
+docker run -v ./config.yaml:/config/config.yaml -v ./data:/data -p 8080:8080 deepcrate
 ```
 
 ## Architecture
 
-Resonance is a music discovery pipeline with a Node.js/TypeScript server and Vue 3 ui.
+DeepCrate is a music discovery pipeline with a Node.js/TypeScript server and Vue 3 ui.
 
 ### Server (`/server/src`)
 
@@ -80,7 +80,7 @@ Vue 3 + TypeScript + Pinia + PrimeVue 4.
 
 **Path alias:** `@/*` maps to `./src/*` (configured in vite.config.ts and tsconfig.app.json)
 
-**Theme:** Custom Resonance preset extending PrimeVue Aura base theme with indigo primary colors and dark mode optimized surfaces. See `assets/styles/theme.ts`.
+**Theme:** Custom DeepCrate preset extending PrimeVue Aura base theme with indigo primary colors and dark mode optimized surfaces. See `assets/styles/theme.ts`.
 
 **Composables Pattern:** Composables wrap Pinia stores for convenient access and don't duplicate state. Always use composables in page components for better separation of concerns.
 
@@ -93,7 +93,7 @@ Vue 3 + TypeScript + Pinia + PrimeVue 4.
 
 ### Database
 
-SQLite via Sequelize 7 alpha. DB file at `$DATA_PATH/resonance.sqlite` (default `/data/resonance.sqlite`).
+SQLite via Sequelize 7 alpha. DB file at `$DATA_PATH/deepcrate.sqlite` (default `/data/deepcrate.sqlite`).
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Resonance
+# Contributing to DeepCrate
 
-Thank you for your interest in contributing to Resonance! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to DeepCrate! This document provides guidelines and information for contributors.
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Thank you for your interest in contributing to Resonance! This document provides
 1. **Clone the repository**
 
 ```bash
-git clone https://github.com/jordojordo/resonance.git
-cd resonance
+git clone https://github.com/jordojordo/deepcrate.git
+cd deepcrate
 ```
 
 2. **Install server dependencies (Node.js/TypeScript)**
@@ -51,7 +51,7 @@ cd server
 pnpm run dev    # Starts on http://localhost:8080 with hot reload
 ```
 
-Resonance runs as a single Node.js process. Background jobs (lb-fetch, catalog-discovery, slskd-downloader) are scheduled via node-cron.
+DeepCrate runs as a single Node.js process. Background jobs (lb-fetch, catalog-discovery, slskd-downloader) are scheduled via node-cron.
 
 You can also trigger jobs via the API actions endpoints (useful for local testing):
 
@@ -102,8 +102,8 @@ pnpm run typecheck
 ## Building and Running with Docker
 
 ```bash
-docker build -t resonance:dev .
-docker run -v ./config.yaml:/config/config.yaml -v ./data:/data -p 8080:8080 resonance:dev
+docker build -t deepcrate:dev .
+docker run -v ./config.yaml:/config/config.yaml -v ./data:/data -p 8080:8080 deepcrate:dev
 ```
 
 ## Project Structure
@@ -111,7 +111,7 @@ docker run -v ./config.yaml:/config/config.yaml -v ./data:/data -p 8080:8080 res
 The server is Node.js/TypeScript and the ui is Vue 3. Local development is typically two processes (server on :8080, ui on :5173).
 
 ```
-resonance/
+deepcrate/
 ├── server/
 │   ├── src/                  # Node.js/TypeScript server code (Express + jobs)
 │   ├── tests/                # Server tests
@@ -245,7 +245,7 @@ Look for issues labeled `good first issue`:
 
 ## Questions?
 
-- Open a [GitHub Discussion](https://github.com/jordojordo/resonance/discussions)
+- Open a [GitHub Discussion](https://github.com/jordojordo/deepcrate/discussions)
 - Check existing issues for similar questions
 - Read the [documentation](docs/)
 
@@ -255,4 +255,4 @@ By contributing, you agree that your contributions will be licensed under the Ap
 
 ---
 
-Thank you for contributing to Resonance!
+Thank you for contributing to DeepCrate!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # =============================================================================
-# Resonance Dockerfile (Node.js Migration)
+# DeepCrate Dockerfile (Node.js Migration)
 # Multi-stage build: UI → Server → Production Runtime
 # =============================================================================
 
@@ -22,13 +22,13 @@ COPY ui/package.json ./ui/
 COPY server/package.json ./server/
 
 # Install UI dependencies using workspace filter
-RUN pnpm --filter @resonance/ui install --frozen-lockfile
+RUN pnpm --filter @deepcrate/ui install --frozen-lockfile
 
 # Copy UI source files
 COPY ui/ ./ui/
 
 # Build production bundle
-RUN pnpm --filter @resonance/ui run build
+RUN pnpm --filter @deepcrate/ui run build
 
 # =============================================================================
 # Stage 2: Build Server
@@ -52,7 +52,7 @@ COPY server/package.json ./server/
 COPY ui/package.json ./ui/
 
 # Install server dependencies (including devDependencies for build)
-RUN pnpm --filter @resonance/server install --frozen-lockfile
+RUN pnpm --filter @deepcrate/server install --frozen-lockfile
 
 # Navigate into sqlite3's actual directory and build it manually
 RUN cd /build/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3 && \
@@ -65,7 +65,7 @@ COPY server/src ./server/src
 COPY server/tsconfig.json server/tsconfig.build.json ./server/
 
 # Build TypeScript to JavaScript
-RUN pnpm --filter @resonance/server run build
+RUN pnpm --filter @deepcrate/server run build
 
 # =============================================================================
 # Stage 3: Production Runtime
@@ -89,7 +89,7 @@ COPY server/package.json ./server/
 COPY ui/package.json ./ui/
 
 # Install production dependencies (this will rebuild native modules for runtime image)
-RUN pnpm --filter @resonance/server install --prod --frozen-lockfile
+RUN pnpm --filter @deepcrate/server install --prod --frozen-lockfile
 
 # Navigate into sqlite3's actual directory and build it manually for production
 RUN cd /app/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3 && \
@@ -119,10 +119,10 @@ ENV NODE_ENV=production \
     RUN_JOBS_ON_STARTUP=true
 
 # Create non-root user (use GID/UID 1001 to avoid conflict with node user at 1000)
-RUN addgroup -g 1001 resonance \
-    && adduser -D -u 1001 -G resonance resonance \
+RUN addgroup -g 1001 deepcrate \
+    && adduser -D -u 1001 -G deepcrate deepcrate \
     && mkdir -p /data /config \
-    && chown -R resonance:resonance /app /data /config
+    && chown -R deepcrate:deepcrate /app /data /config
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin/
@@ -135,5 +135,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
-# Entrypoint handles permissions and drops to resonance user
+# Entrypoint handles permissions and drops to deepcrate user
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Resonance
+# DeepCrate
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fjordojordo%2Fresonance-blue)](https://ghcr.io/jordojordo/resonance)
+[![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fjordojordo%2Fdeepcrate-blue)](https://ghcr.io/jordojordo/deepcrate)
 [![AI Assisted](https://img.shields.io/badge/AI-Claude_Code-D97757?logo=claude&logoColor=fff)](https://claude.ai/code)
 
-**A digital record shop for your self-hosted library.** Resonance surfaces music through your listening history and existing collection, lets you preview and approve recommendations, then downloads via Soulseek.
+**A digital record shop for your self-hosted library.** DeepCrate surfaces music through your listening history and existing collection, lets you preview and approve recommendations, then downloads via Soulseek.
 
 https://github.com/user-attachments/assets/8e33838e-a73d-4489-9b72-44cdd9ec8d99
 
@@ -46,7 +46,7 @@ flowchart LR
 ### 1. Create configuration
 
 ```bash
-mkdir -p resonance/data && cd resonance
+mkdir -p deepcrate/data && cd deepcrate
 ```
 
 Create `config.yaml`:
@@ -83,9 +83,9 @@ Create `docker-compose.yaml`:
 
 ```yaml
 services:
-  resonance:
-    image: ghcr.io/jordojordo/resonance:latest
-    container_name: resonance
+  deepcrate:
+    image: ghcr.io/jordojordo/deepcrate:latest
+    container_name: deepcrate
     volumes:
       - ./config.yaml:/config/config.yaml:rw
       - ./data:/data
@@ -109,7 +109,7 @@ Open `http://localhost:8080` and log in with your configured credentials.
 ## Development
 
 ```bash
-git clone https://github.com/jordojordo/resonance.git && cd resonance
+git clone https://github.com/jordojordo/deepcrate.git && cd deepcrate
 pnpm install && pnpm dev  # Starts on http://localhost:5173
 ```
 
@@ -117,7 +117,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Alternatives
 
-Resonance focuses on **curated discovery**, meaning you approve what enters your library. If you prefer fully automated weekly playlists, check out [Explo](https://github.com/LumePart/Explo). If you need to monitor known artists for new releases, [Lidarr](https://lidarr.audio/) is the standard. See [Comparison](docs/comparison.md) for a detailed breakdown.
+DeepCrate focuses on **curated discovery**, meaning you approve what enters your library. If you prefer fully automated weekly playlists, check out [Explo](https://github.com/LumePart/Explo). If you need to monitor known artists for new releases, [Lidarr](https://lidarr.audio/) is the standard. See [Comparison](docs/comparison.md) for a detailed breakdown.
 
 ## Related Projects
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,20 +4,20 @@ set -e
 # Ensure data and config directories exist and are writable
 # This handles the case where bind mounts override the image's directory permissions
 
-# If running as root, fix permissions and re-exec as resonance user
+# If running as root, fix permissions and re-exec as deepcrate user
 if [ "$(id -u)" = "0" ]; then
     # Ensure directories exist
     mkdir -p /data /config
 
     # Fix ownership for data directory (needs write access)
-    chown -R resonance:resonance /data
+    chown -R deepcrate:deepcrate /data
 
     # Config directory may be read-only mounted, only chown if writable
-    chown -R resonance:resonance /config 2>/dev/null || true
+    chown -R deepcrate:deepcrate /config 2>/dev/null || true
 
-    # Re-exec this script as resonance user
-    exec su-exec resonance "$0" "$@"
+    # Re-exec this script as deepcrate user
+    exec su-exec deepcrate "$0" "$@"
 fi
 
-# Now running as resonance user - start the application
+# Now running as deepcrate user - start the application
 exec node server/dist/server.js

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Resonance exposes a REST API for managing the music discovery pipeline.
+DeepCrate exposes a REST API for managing the music discovery pipeline.
 
 ## Base URL
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,14 @@
-# Resonance Architecture
+# DeepCrate Architecture
 
 ## Overview
 
-Resonance is designed as a self-contained, single-container application that runs multiple services using s6-overlay for process supervision. This document describes the technical architecture.
+DeepCrate is designed as a self-contained, single-container application that runs multiple services using s6-overlay for process supervision. This document describes the technical architecture.
 
 ## System Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                           RESONANCE CONTAINER                               │
+│                           DEEPCRATE CONTAINER                               │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                             │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
@@ -293,7 +293,7 @@ Three options:
 For production deployments, use Authelia via reverse proxy forward auth:
 
 ```
-Client → Reverse Proxy (Caddy/nginx/Traefik) → Authelia (verify) → Resonance
+Client → Reverse Proxy (Caddy/nginx/Traefik) → Authelia (verify) → DeepCrate
 ```
 
 Supported reverse proxies:
@@ -316,7 +316,7 @@ The container is lightweight - most resource usage comes from API calls to exter
 
 ## Scalability
 
-Resonance is designed for single-user/household use. It is **not** designed for:
+DeepCrate is designed for single-user/household use. It is **not** designed for:
 - Multi-tenant deployments
 - Horizontal scaling
 - High-availability
@@ -328,8 +328,8 @@ For larger deployments, consider running multiple instances with separate config
 Logs are written to stdout/stderr and can be viewed via:
 
 ```bash
-docker logs resonance
-docker logs -f resonance  # Follow
+docker logs deepcrate
+docker logs -f deepcrate  # Follow
 ```
 
 Log levels are controlled via `LOG_LEVEL` environment variable.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,12 +1,12 @@
-# Resonance vs Alternatives
+# DeepCrate vs Alternatives
 
-This document compares Resonance to similar self-hosted music discovery and automation tools. The goal is to help newcomers understand where Resonance fits in the ecosystem and what makes it distinct.
+This document compares DeepCrate to similar self-hosted music discovery and automation tools. The goal is to help newcomers understand where DeepCrate fits in the ecosystem and what makes it distinct.
 
-Resonance's design philosophy is the **digital record shop**: you browse curated crates shaped by your listening history and existing collection, preview what catches your ear, and decide what to take home. Other tools in this space optimize for automation; Resonance optimizes for intentional discovery.
+DeepCrate's design philosophy is the **digital record shop**: you browse curated crates shaped by your listening history and existing collection, preview what catches your ear, and decide what to take home. Other tools in this space optimize for automation; DeepCrate optimizes for intentional discovery.
 
 ## Quick Comparison
 
-| Feature | Resonance | Explo | SoulSync | Lidarr | Lidify | Soularr | Beets |
+| Feature | DeepCrate | Explo | SoulSync | Lidarr | Lidify | Soularr | Beets |
 |---|---|---|---|---|---|---|---|
 | **Primary purpose** | Discovery pipeline with curation | Automated playlist generation | All-in-one automation platform | Collection management | Music server + discovery | Lidarr-to-Soulseek bridge | Library organization |
 | **Discovery source** | ListenBrainz + Last.fm catalog | ListenBrainz | Spotify + music-map.com + Beatport | Manual artist monitoring | Last.fm similar artists | None (uses Lidarr wants) | None |
@@ -16,39 +16,39 @@ Resonance's design philosophy is the **digital record shop**: you browse curated
 | **Web UI** | Dashboard, queue, downloads | CLI/headless only | Full management UI | Full management UI | Full player UI | CLI/headless |  Basic optional |
 | **Music server support** | Subsonic-compatible servers | Jellyfin, Emby, Plex, MPD, Subsonic | Plex, Jellyfin, Navidrome | Standalone | Standalone (is a server) | Via Lidarr | None (organizer) |
 
-## Resonance vs Explo
+## DeepCrate vs Explo
 
-[Explo](https://github.com/LumePart/Explo) is the closest alternative to Resonance in terms of scope. Both pull recommendations from ListenBrainz and can download via slskd. However, they differ meaningfully in philosophy and workflow.
+[Explo](https://github.com/LumePart/Explo) is the closest alternative to DeepCrate in terms of scope. Both pull recommendations from ListenBrainz and can download via slskd. However, they differ meaningfully in philosophy and workflow.
 
 ### Where they overlap
 
 Both tools solve the same core problem: turning ListenBrainz listening data into actual music files on your server. Both support Soulseek via slskd as a download backend, both run as single Docker containers, and both target the self-hosted music community.
 
-### Where Resonance differs
+### Where DeepCrate differs
 
-**Curation over automation.** Explo is designed to be fire-and-forget. It fetches ListenBrainz playlists (Weekly Exploration, Weekly Jams, Daily Jams), downloads the tracks, and creates a playlist on your music server. Resonance takes a different approach. It presents discoveries in a pending queue where you can preview, approve, or reject each recommendation before anything downloads. This is intentional: the approval workflow gives you control over what enters your library, which matters if you care about library quality and coherence.
+**Curation over automation.** Explo is designed to be fire-and-forget. It fetches ListenBrainz playlists (Weekly Exploration, Weekly Jams, Daily Jams), downloads the tracks, and creates a playlist on your music server. DeepCrate takes a different approach. It presents discoveries in a pending queue where you can preview, approve, or reject each recommendation before anything downloads. This is intentional: the approval workflow gives you control over what enters your library, which matters if you care about library quality and coherence.
 
-**Catalog discovery (ListenBrainz and Last.fm similar artists).** This is Resonance's most distinct feature. In addition to ListenBrainz recommendations (which are based on your *listening history*), Resonance scans your Navidrome library and queries ListenBrainz and Last.fm for artists similar to ones you already own. It then aggregates similarity scores across your collection, so an artist who is similar to *multiple* artists in your library ranks higher than one who's only similar to a single artist. This means Resonance can discover music through two independent paths: what you listen to and what you own. Explo only uses the listening history path.
+**Catalog discovery (ListenBrainz and Last.fm similar artists).** This is DeepCrate's most distinct feature. In addition to ListenBrainz recommendations (which are based on your *listening history*), DeepCrate scans your Navidrome library and queries ListenBrainz and Last.fm for artists similar to ones you already own. It then aggregates similarity scores across your collection, so an artist who is similar to *multiple* artists in your library ranks higher than one who's only similar to a single artist. This means DeepCrate can discover music through two independent paths: what you listen to and what you own. Explo only uses the listening history path.
 
-**Audio previews.** Resonance lets you listen to 30-second audio previews (via Deezer or Spotify) directly in the Web UI before approving a download. This is a significant UX advantage when you're deciding whether to commit library space to a new artist or album.
+**Audio previews.** DeepCrate lets you listen to 30-second audio previews (via Deezer or Spotify) directly in the Web UI before approving a download. This is a significant UX advantage when you're deciding whether to commit library space to a new artist or album.
 
-**Interactive source selection.** When downloading, Resonance can show you multiple download sources from Soulseek, letting you compare file quality, format, and completeness before choosing which one to grab. Explo's downloads are fully automated with no manual source selection.
+**Interactive source selection.** When downloading, DeepCrate can show you multiple download sources from Soulseek, letting you compare file quality, format, and completeness before choosing which one to grab. Explo's downloads are fully automated with no manual source selection.
 
-**Album-oriented workflow.** Resonance resolves track recommendations to their parent albums via MusicBrainz, then presents albums as the unit of approval. This aligns with how many collectors think about building a library. Explo is track-oriented, creating playlists of individual songs, more like a streaming "Discover Weekly" experience.
+**Album-oriented workflow.** DeepCrate resolves track recommendations to their parent albums via MusicBrainz, then presents albums as the unit of approval. This aligns with how many collectors think about building a library. Explo is track-oriented, creating playlists of individual songs, more like a streaming "Discover Weekly" experience.
 
-**Web UI.** Resonance ships with a full Vue 3 dashboard for managing the discovery pipeline: queue management, download monitoring, library stats, settings. Explo is a headless CLI tool with no web interface.
+**Web UI.** DeepCrate ships with a full Vue 3 dashboard for managing the discovery pipeline: queue management, download monitoring, library stats, settings. Explo is a headless CLI tool with no web interface.
 
 ### Where Explo has advantages
 
-**Broader music server support.** Explo creates playlists directly on Jellyfin, Emby, Plex, MPD, and any Subsonic-compatible server. Resonance currently integrates with Subsonic-compatible servers for library scanning but downloads into a directory rather than creating playlists on arbitrary servers.
+**Broader music server support.** Explo creates playlists directly on Jellyfin, Emby, Plex, MPD, and any Subsonic-compatible server. DeepCrate currently integrates with Subsonic-compatible servers for library scanning but downloads into a directory rather than creating playlists on arbitrary servers.
 
-**YouTube downloads.** Explo supports downloading from YouTube (via yt-dlp) in addition to Soulseek. Resonance currently only supports slskd.
+**YouTube downloads.** Explo supports downloading from YouTube (via yt-dlp) in addition to Soulseek. DeepCrate currently only supports slskd.
 
-**Simpler setup for passive discovery.** If you want a fully automated "just give me new music every week" experience without any manual intervention, Explo's simplicity is a strength. Resonance's approval workflow is powerful but requires engagement.
+**Simpler setup for passive discovery.** If you want a fully automated "just give me new music every week" experience without any manual intervention, Explo's simplicity is a strength. DeepCrate's approval workflow is powerful but requires engagement.
 
 **More mature.** Explo has been around longer and has a larger community, which translates to more battle-tested edge cases.
 
-## Resonance vs SoulSync
+## DeepCrate vs SoulSync
 
 [SoulSync](https://github.com/Nezreka/SoulSync) is an all-in-one music automation platform that combines discovery, downloading, playlist generation, metadata tagging, and library management into a single application. It's the most feature-rich tool in this space.
 
@@ -56,80 +56,80 @@ Both tools solve the same core problem: turning ListenBrainz listening data into
 
 Both tools discover music and download via slskd, both offer web UIs for managing the pipeline, both do duplicate detection against your existing library, and both target the self-hosted music community.
 
-### Where Resonance differs
+### Where DeepCrate differs
 
-**Curation vs automation.** This is the fundamental split. SoulSync's tagline is "zero manual effort", it automates the entire chain from discovery to organized files. Resonance puts human judgment at the center: you browse, preview, and approve before anything downloads. If you care about intentionally building a library rather than accumulating tracks, the approval workflow matters.
+**Curation vs automation.** This is the fundamental split. SoulSync's tagline is "zero manual effort", it automates the entire chain from discovery to organized files. DeepCrate puts human judgment at the center: you browse, preview, and approve before anything downloads. If you care about intentionally building a library rather than accumulating tracks, the approval workflow matters.
 
-**No Spotify dependency.** SoulSync's richest discovery features (Discovery Weekly, personalized playlists, metadata) depend on Spotify's API, falling back to iTunes when unavailable. Resonance uses ListenBrainz and Last.fm exclusively, open services with no proprietary API dependency.
+**No Spotify dependency.** SoulSync's richest discovery features (Discovery Weekly, personalized playlists, metadata) depend on Spotify's API, falling back to iTunes when unavailable. DeepCrate uses ListenBrainz and Last.fm exclusively, open services with no proprietary API dependency.
 
-**Album-oriented workflow.** Resonance resolves track-level recommendations to their parent albums via MusicBrainz, presenting albums as the unit of approval. SoulSync is track-oriented, generating playlists of individual songs. This reflects different philosophies about how a library should grow.
+**Album-oriented workflow.** DeepCrate resolves track-level recommendations to their parent albums via MusicBrainz, presenting albums as the unit of approval. SoulSync is track-oriented, generating playlists of individual songs. This reflects different philosophies about how a library should grow.
 
-**Catalog discovery.** Resonance scans your Subsonic library and queries ListenBrainz and Last.fm for artists similar to ones you already own, aggregating similarity scores across your collection. This means an artist similar to *multiple* artists you own ranks higher. SoulSync uses music-map.com for similar artist lookups from a watchlist, which doesn't weight against your full library.
+**Catalog discovery.** DeepCrate scans your Subsonic library and queries ListenBrainz and Last.fm for artists similar to ones you already own, aggregating similarity scores across your collection. This means an artist similar to *multiple* artists you own ranks higher. SoulSync uses music-map.com for similar artist lookups from a watchlist, which doesn't weight against your full library.
 
-**Focused scope.** Resonance deliberately delegates post-download work (tagging, organizing, metadata) to specialized tools like beets or wrtag. SoulSync handles tagging, LRC lyrics, file organization templates, quality scanning, and duplicate cleaning itself. Resonance's restraint keeps the codebase lean and composable with existing toolchains.
+**Focused scope.** DeepCrate deliberately delegates post-download work (tagging, organizing, metadata) to specialized tools like beets or wrtag. SoulSync handles tagging, LRC lyrics, file organization templates, quality scanning, and duplicate cleaning itself. DeepCrate's restraint keeps the codebase lean and composable with existing toolchains.
 
 ### Where SoulSync has advantages
 
-**Broader download sources.** SoulSync downloads from Soulseek, YouTube (via yt-dlp), and Beatport charts. Resonance currently only supports slskd.
+**Broader download sources.** SoulSync downloads from Soulseek, YouTube (via yt-dlp), and Beatport charts. DeepCrate currently only supports slskd.
 
-**Playlist generation.** SoulSync generates 12+ playlist types: Release Radar, Discovery Weekly, seasonal playlists, decade/genre mixes, daily mixes, and more. Resonance doesn't generate playlists, its output is approved albums in your library.
+**Playlist generation.** SoulSync generates 12+ playlist types: Release Radar, Discovery Weekly, seasonal playlists, decade/genre mixes, daily mixes, and more. DeepCrate doesn't generate playlists, its output is approved albums in your library.
 
-**Artist monitoring.** SoulSync includes a watchlist for monitoring artists and auto-detecting new releases, similar to Lidarr. Resonance focuses on discovering new-to-you artists rather than tracking known ones.
+**Artist monitoring.** SoulSync includes a watchlist for monitoring artists and auto-detecting new releases, similar to Lidarr. DeepCrate focuses on discovering new-to-you artists rather than tracking known ones.
 
-**Built-in library management.** Quality scanning (find low-bitrate files), duplicate cleaning, album completion tracking, and template-based file organization are all built in. Resonance expects you to use other tools for these tasks.
+**Built-in library management.** Quality scanning (find low-bitrate files), duplicate cleaning, album completion tracking, and template-based file organization are all built in. DeepCrate expects you to use other tools for these tasks.
 
-**Broader server support.** SoulSync syncs with Plex, Jellyfin, and Navidrome. Resonance integrates with Subsonic-compatible servers only.
+**Broader server support.** SoulSync syncs with Plex, Jellyfin, and Navidrome. DeepCrate integrates with Subsonic-compatible servers only.
 
-**Metadata enrichment.** SoulSync fetches synchronized lyrics (LRC), album art, and proper tags automatically. Resonance delegates metadata work to external tools.
+**Metadata enrichment.** SoulSync fetches synchronized lyrics (LRC), album art, and proper tags automatically. DeepCrate delegates metadata work to external tools.
 
-## Resonance vs Lidarr
+## DeepCrate vs Lidarr
 
-[Lidarr](https://lidarr.audio/) is a music collection manager in the *arr ecosystem (Sonarr, Radarr, etc.). It solves a fundamentally different problem than Resonance.
+[Lidarr](https://lidarr.audio/) is a music collection manager in the *arr ecosystem (Sonarr, Radarr, etc.). It solves a fundamentally different problem than DeepCrate.
 
-**Lidarr manages; Resonance discovers.** Lidarr monitors artists and albums you've told it about, watches for new releases, and downloads them automatically via Usenet or BitTorrent. It doesn't discover new artists for you, you need to manually add every artist you want to track. Resonance is the opposite: its entire purpose is surfacing artists and albums you *don't already know about*.
+**Lidarr manages; DeepCrate discovers.** Lidarr monitors artists and albums you've told it about, watches for new releases, and downloads them automatically via Usenet or BitTorrent. It doesn't discover new artists for you, you need to manually add every artist you want to track. DeepCrate is the opposite: its entire purpose is surfacing artists and albums you *don't already know about*.
 
-**Different download networks.** Lidarr integrates with Usenet indexers and BitTorrent trackers through a robust download client ecosystem. Resonance uses Soulseek via slskd, which is a different network with different content availability tradeoffs.
+**Different download networks.** Lidarr integrates with Usenet indexers and BitTorrent trackers through a robust download client ecosystem. DeepCrate uses Soulseek via slskd, which is a different network with different content availability tradeoffs.
 
-**Complementary tools.** Lidarr and Resonance can work well together. Resonance finds new music and gets it into your library; Lidarr can then monitor those artists for future releases. They don't compete, they address different stages of the music acquisition pipeline.
+**Complementary tools.** Lidarr and DeepCrate can work well together. DeepCrate finds new music and gets it into your library; Lidarr can then monitor those artists for future releases. They don't compete, they address different stages of the music acquisition pipeline.
 
-## Resonance vs Lidify
+## DeepCrate vs Lidify
 
 [Lidify](https://github.com/Chevron7Locked/lidify) is a full-featured music server and player with discovery features built in. It includes audio transcoding, playlist generation, vibe-based matching, Spotify/Deezer import, and ML mood detection.
 
-The overlap with Resonance is narrow. Lidify uses Last.fm similar artist data for discovery (like Resonance's catalog discovery), but it's fundamentally a music server replacement rather than a discovery pipeline. Lidify doesn't download music on its own, it relies on Lidarr integration for acquisition. Resonance is laser-focused on the discovery-to-download workflow and delegates playback to your existing music server.
+The overlap with DeepCrate is narrow. Lidify uses Last.fm similar artist data for discovery (like DeepCrate's catalog discovery), but it's fundamentally a music server replacement rather than a discovery pipeline. Lidify doesn't download music on its own, it relies on Lidarr integration for acquisition. DeepCrate is laser-focused on the discovery-to-download workflow and delegates playback to your existing music server.
 
-## Resonance vs Soularr
+## DeepCrate vs Soularr
 
 [Soularr](https://github.com/mrusse/soularr) bridges Lidarr to Soulseek via slskd, enabling automated downloads of albums marked "wanted" in Lidarr. It's the most direct alternative for Soulseek-based acquisition.
 
-**Key difference: Discovery vs Acquisition.** Soularr is purely an acquisition tool, it downloads what you've already decided you want in Lidarr. Resonance is a discovery tool that surfaces music you don't know about yet, then handles acquisition.
+**Key difference: Discovery vs Acquisition.** Soularr is purely an acquisition tool, it downloads what you've already decided you want in Lidarr. DeepCrate is a discovery tool that surfaces music you don't know about yet, then handles acquisition.
 
 **Workflow comparison:**
 - Soularr: You mark albums wanted in Lidarr -> Soularr searches slskd -> Downloads import to Lidarr
-- Resonance: ListenBrainz/Last.fm discover albums -> You approve in queue -> Downloads go to your library
+- DeepCrate: ListenBrainz/Last.fm discover albums -> You approve in queue -> Downloads go to your library
 
 **Where Soularr fits:** If you're deeply invested in the Lidarr ecosystem and maintain manual want lists, Soularr provides reliable hands-off Soulseek acquisition. It's battle-tested Python with quality controls (format preferences, regional filtering, multi-disc handling).
 
-**Where Resonance differs:** Resonance doesn't require Lidarr, it works directly with any Subsonic-compatible server. Its value is in the discovery pipeline (what to download) rather than just the acquisition mechanics (how to download).
+**Where DeepCrate differs:** DeepCrate doesn't require Lidarr, it works directly with any Subsonic-compatible server. Its value is in the discovery pipeline (what to download) rather than just the acquisition mechanics (how to download).
 
-## Resonance vs Beets
+## DeepCrate vs Beets
 
 [Beets](https://beets.io/) is the gold standard for music library organization and metadata management. It auto-tags files, fetches cover art, normalizes volume, and organizes your collection with customizable folder structures.
 
-**Different stages of the pipeline.** Beets operates *after* you have music files, it organizes what you already own. Resonance operates *before*, it discovers what to acquire. They're complementary, not competitive.
+**Different stages of the pipeline.** Beets operates *after* you have music files, it organizes what you already own. DeepCrate operates *before*, it discovers what to acquire. They're complementary, not competitive.
 
 **Potential workflow integration:**
-1. Resonance discovers and downloads music via slskd
+1. DeepCrate discovers and downloads music via slskd
 2. Beets imports the downloads, correcting metadata and organizing files
 3. Your Subsonic server picks up the organized library
 
 **No discovery features:** Despite having 70+ plugins, Beets has no music recommendation or discovery capabilities. Its Last.fm integration is for fetching genre tags, not finding similar artists.
 
-**When to use both:** If you care deeply about metadata accuracy and folder organization, run Beets as a post-processing step after Resonance downloads complete.
+**When to use both:** If you care deeply about metadata accuracy and folder organization, run Beets as a post-processing step after DeepCrate downloads complete.
 
-## When to choose Resonance
+## When to choose DeepCrate
 
-Resonance is the right choice if you:
+DeepCrate is the right choice if you:
 
 - Want **curated discovery**: You care about what enters your library and want to approve recommendations before downloading
 - Value **multiple discovery sources**: Combining listening history (ListenBrainz) with library analysis (Last.fm catalog discovery) gives broader coverage
@@ -151,4 +151,4 @@ Resonance is the right choice if you:
 
 ## Roadmap context
 
-Resonance is in active early development, the project's scope and integrations will expand over time. See the [project board](https://github.com/jordojordo/resonance/projects) and [open issues](https://github.com/jordojordo/resonance/issues) for planned features.
+DeepCrate is in active early development, the project's scope and integrations will expand over time. See the [project board](https://github.com/jordojordo/deepcrate/projects) and [open issues](https://github.com/jordojordo/deepcrate/issues) for planned features.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Resonance is configured via a YAML file mounted at `/config/config.yaml`.
+DeepCrate is configured via a YAML file mounted at `/config/config.yaml`.
 
 ## Full Configuration Example
 
@@ -190,11 +190,11 @@ library_organize:
   # Enable library organization
   enabled: false
 
-  # Where slskd saves completed downloads (must be accessible to Resonance)
+  # Where slskd saves completed downloads (must be accessible to DeepCrate)
   # This path must be mounted as a volume in your docker-compose.yaml
   downloads_path: "/downloads/complete"
 
-  # Destination music library path (must be accessible to Resonance)
+  # Destination music library path (must be accessible to DeepCrate)
   # This path must be mounted as a volume in your docker-compose.yaml
   library_path: "/music/library"
 
@@ -274,22 +274,22 @@ Environment variables can override or supplement the config file:
 | `LOG_TO_FILE` | `false` | Enable file logging |
 | `CONFIG_PATH` | `/config/config.yaml` | Path to config file |
 | `DATA_PATH` | `/data` | Path to data directory |
-| `RESONANCE_DB_FILE` | `DATA_PATH/resonance.sqlite` | SQLite DB file path |
-| `RESONANCE_DB_LOGGING` | `false` | Enable Sequelize SQL logging (`true`/`false`) |
+| `DEEPCRATE_DB_FILE` | `DATA_PATH/deepcrate.sqlite` | SQLite DB file path |
+| `DEEPCRATE_DB_LOGGING` | `false` | Enable Sequelize SQL logging (`true`/`false`) |
 
 ### Override Config Values via Environment
 
-Config values can be overridden using environment variables with the `RESONANCE_` prefix:
+Config values can be overridden using environment variables with the `DEEPCRATE_` prefix:
 
 ```bash
 # Override ListenBrainz username
-RESONANCE_LISTENBRAINZ__USERNAME=myuser
+DEEPCRATE_LISTENBRAINZ__USERNAME=myuser
 
 # Override slskd host
-RESONANCE_SLSKD__HOST=http://10.100.0.11:5030
+DEEPCRATE_SLSKD__HOST=http://10.100.0.11:5030
 
 # Override catalog discovery enabled
-RESONANCE_CATALOG_DISCOVERY__ENABLED=false
+DEEPCRATE_CATALOG_DISCOVERY__ENABLED=false
 ```
 
 Note: Use double underscore `__` for nested keys.
@@ -505,7 +505,7 @@ When `enabled: false`, the UI behaves the same as `proxy` mode - users are autom
 
 ## Minimal Configuration
 
-The bare minimum to run Resonance with ListenBrainz only:
+The bare minimum to run DeepCrate with ListenBrainz only:
 
 ```yaml
 listenbrainz:
@@ -521,8 +521,8 @@ slskd:
 
 ```yaml
 services:
-  resonance:
-    image: ghcr.io/jordojordo/resonance:latest
+  deepcrate:
+    image: ghcr.io/jordojordo/deepcrate:latest
     environment:
       - LB_FETCH_INTERVAL=21600
       - CATALOG_INTERVAL=604800
@@ -537,7 +537,7 @@ services:
 
 ## Config Validation
 
-On startup, Resonance validates the configuration and logs any issues:
+On startup, DeepCrate validates the configuration and logs any issues:
 
 ```
 2026-01-11 10:00:00 - INFO - Loading configuration from /config/config.yaml
@@ -570,12 +570,12 @@ listenbrainz:
 ```yaml
 # docker-compose.yaml
 services:
-  resonance:
+  deepcrate:
     secrets:
       - listenbrainz_token
       - slskd_api_key
     environment:
-      - RESONANCE_LISTENBRAINZ__TOKEN_FILE=/run/secrets/listenbrainz_token
+      - DEEPCRATE_LISTENBRAINZ__TOKEN_FILE=/run/secrets/listenbrainz_token
 
 secrets:
   listenbrainz_token:
@@ -593,7 +593,7 @@ For Kubernetes or advanced setups, mount secrets as files and reference via `*_F
 The UI supports importing and exporting wishlist items as JSON files. This is useful for:
 - Bulk importing wishlists from other sources
 - Backing up your wishlist
-- Migrating between Resonance instances
+- Migrating between DeepCrate instances
 
 ### JSON Schema
 
@@ -660,7 +660,7 @@ Import files must be a JSON array of objects with the following structure:
 
 ## Network Requirements
 
-Resonance needs network access to the following services:
+DeepCrate needs network access to the following services:
 
 | Service | Purpose |
 |---------|---------|

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Resonance Configuration Example
+# DeepCrate Configuration Example
 # Copy this file to config.yaml and fill in your values
 # =============================================================================
 
@@ -54,7 +54,7 @@ slskd:
   # web:
   #   authentication:
   #     api_keys:
-  #       resonance:
+  #       deepcrate:
   #         key: "your_api_key"
   #         role: readwrite
   api_key: "your_slskd_api_key"
@@ -200,12 +200,12 @@ library_organize:
   # Enable library organization
   enabled: false
 
-  # Where slskd saves completed downloads (must be accessible to Resonance)
+  # Where slskd saves completed downloads (must be accessible to DeepCrate)
   # This path must be mounted as a volume in your docker-compose.yaml
   # Example: ./downloads/complete:/downloads/complete:rw
   downloads_path: "/downloads/complete"
 
-  # Destination music library path (must be accessible to Resonance)
+  # Destination music library path (must be accessible to DeepCrate)
   # This path must be mounted as a volume in your docker-compose.yaml
   # Example: ./music:/music/library:rw
   library_path: "/music/library"

--- a/examples/docker-compose.authelia.yaml
+++ b/examples/docker-compose.authelia.yaml
@@ -1,22 +1,22 @@
 # =============================================================================
-# Resonance Docker Compose with Authelia
+# DeepCrate Docker Compose with Authelia
 # Production deployment with external authentication
 # =============================================================================
 
 services:
   # ---------------------------------------------------------------------------
-  # Resonance - Music Discovery
+  # DeepCrate - Music Discovery
   # ---------------------------------------------------------------------------
-  resonance:
-    image: ghcr.io/jordojordo/resonance:latest
-    container_name: resonance
+  deepcrate:
+    image: ghcr.io/jordojordo/deepcrate:latest
+    container_name: deepcrate
     environment:
       - LOG_LEVEL=info
     volumes:
-      - ./resonance/config.yaml:/config/config.yaml:rw
-      - ./resonance/data:/data
+      - ./deepcrate/config.yaml:/config/config.yaml:rw
+      - ./deepcrate/data:/data
     networks:
-      - resonance-net
+      - deepcrate-net
     # No ports exposed - access via Caddy only
     restart: unless-stopped
 
@@ -34,9 +34,9 @@ services:
       - caddy-data:/data
       - caddy-config:/config
     networks:
-      - resonance-net
+      - deepcrate-net
     depends_on:
-      - resonance
+      - deepcrate
       - authelia
     restart: unless-stopped
 
@@ -49,7 +49,7 @@ services:
     volumes:
       - ./authelia:/config
     networks:
-      - resonance-net
+      - deepcrate-net
     environment:
       - TZ=America/New_York
     restart: unless-stopped
@@ -63,11 +63,11 @@ services:
     volumes:
       - redis-data:/data
     networks:
-      - resonance-net
+      - deepcrate-net
     restart: unless-stopped
 
 networks:
-  resonance-net:
+  deepcrate-net:
     driver: bridge
 
 volumes:

--- a/examples/docker-compose.combined.yaml
+++ b/examples/docker-compose.combined.yaml
@@ -1,15 +1,15 @@
 # =============================================================================
-# Resonance + slskd Combined Docker Compose Example
+# DeepCrate + slskd Combined Docker Compose Example
 # Deploy both services together with shared volumes for library organization
 #
-# Use this when you want to run slskd and Resonance together.
-# See docker-compose.yaml for standalone Resonance deployment.
+# Use this when you want to run slskd and DeepCrate together.
+# See docker-compose.yaml for standalone DeepCrate deployment.
 # =============================================================================
 
 services:
-  resonance:
-    image: ghcr.io/jordojordo/resonance:latest
-    container_name: resonance
+  deepcrate:
+    image: ghcr.io/jordojordo/deepcrate:latest
+    container_name: deepcrate
     environment:
       - LOG_LEVEL=info
       # Discovery intervals (optional, these are defaults)
@@ -32,7 +32,7 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - resonance-net
+      - deepcrate-net
     depends_on:
       - slskd
     restart: unless-stopped
@@ -49,7 +49,7 @@ services:
       # slskd configuration and data
       - ./slskd/config:/app:rw
 
-      # Downloads directory (shared with Resonance for library organization)
+      # Downloads directory (shared with DeepCrate for library organization)
       - ./downloads:/downloads:rw
 
       # Music to share on Soulseek (read-only)
@@ -60,11 +60,11 @@ services:
       # Web UI port
       - "5030:5030"
     networks:
-      - resonance-net
+      - deepcrate-net
     restart: unless-stopped
 
 networks:
-  resonance-net:
+  deepcrate-net:
     driver: bridge
 
 # =============================================================================
@@ -74,13 +74,13 @@ networks:
 # After setup, your directory should look like:
 #
 # ./
-# ├── config.yaml              # Resonance config
+# ├── config.yaml              # DeepCrate config
 # ├── docker-compose.yaml      # This file
-# ├── data/                    # Resonance state (SQLite DB, logs)
+# ├── data/                    # DeepCrate state (SQLite DB, logs)
 # ├── downloads/
-# │   ├── complete/            # slskd completed downloads -> Resonance reads from here
+# │   ├── complete/            # slskd completed downloads -> DeepCrate reads from here
 # │   └── incomplete/          # slskd in-progress downloads
-# ├── music/                   # Your music library (shared with slskd and Resonance)
+# ├── music/                   # Your music library (shared with slskd and DeepCrate)
 # └── slskd/
 #     └── config/
 #         └── slskd.yml        # slskd configuration
@@ -106,12 +106,12 @@ networks:
 #   port: 5030
 #   authentication:
 #     api_keys:
-#       resonance:
+#       deepcrate:
 #         key: "generate-a-secure-api-key-here"
 #         role: readwrite
 #
 # =============================================================================
-# Resonance config.yaml library_organize section
+# DeepCrate config.yaml library_organize section
 # =============================================================================
 #
 # library_organize:

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Resonance Docker Compose Example
+# DeepCrate Docker Compose Example
 # Standalone deployment (slskd running separately)
 #
 # Use this when you already have slskd running in another container/compose.
@@ -7,9 +7,9 @@
 # =============================================================================
 
 services:
-  resonance:
-    image: ghcr.io/jordojordo/resonance:latest
-    container_name: resonance
+  deepcrate:
+    image: ghcr.io/jordojordo/deepcrate:latest
+    container_name: deepcrate
     environment:
       # Discovery intervals (optional, these are defaults)
       # - LB_FETCH_INTERVAL=21600      # 6 hours
@@ -36,7 +36,7 @@ services:
       - "8080:8080"
     restart: unless-stopped
 
-    # IMPORTANT: If slskd is running in Docker, Resonance must be on the same
+    # IMPORTANT: If slskd is running in Docker, DeepCrate must be on the same
     # network to reach it via hostname (e.g., http://slskd:5030)
     # networks:
     #   - slskd-network

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "resonance-monorepo",
+  "name": "deepcrate-monorepo",
   "private": true,
   "scripts": {
     "deps:check": "pnpm list -r",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resonance/server",
+  "name": "@deepcrate/server",
   "version": "0.1.0",
   "description": "Self-hosted music discovery pipeline server",
   "main": "dist/server.js",

--- a/server/src/config/db/index.ts
+++ b/server/src/config/db/index.ts
@@ -41,7 +41,7 @@ export async function initDb(): Promise<void> {
     // Sync tables from model definitions (creates tables, indexes, etc.)
     await sequelize.sync();
 
-    logger.info('[db] connected and synced', { file: process.env.RESONANCE_DB_FILE });
+    logger.info('[db] connected and synced', { file: process.env.DEEPCRATE_DB_FILE });
   } catch(error) {
     logger.error('[db] failed to initialize', { error: (error as Error)?.message ?? String(error) });
 

--- a/server/src/config/db/sequelize.ts
+++ b/server/src/config/db/sequelize.ts
@@ -11,12 +11,34 @@ if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR, { recursive: true });
 }
 
-const DB_FILE = process.env.RESONANCE_DB_FILE || path.join(DATA_DIR, 'resonance.sqlite');
+function resolveDbFile(): string {
+  if (process.env.DEEPCRATE_DB_FILE) {
+    return process.env.DEEPCRATE_DB_FILE;
+  }
+
+  const newPath = path.join(DATA_DIR, 'deepcrate.sqlite');
+  const legacyPath = path.join(DATA_DIR, 'resonance.sqlite');
+
+  if (!fs.existsSync(newPath) && fs.existsSync(legacyPath)) {
+    logger.warn(
+      'DEPRECATION: '
+      + 'Using legacy database file \'resonance.sqlite\'. '
+      + 'Please rename to \'deepcrate.sqlite\'. '
+      + 'This fallback will be removed in a future version.'
+    );
+
+    return legacyPath;
+  }
+
+  return newPath;
+}
+
+const DB_FILE = resolveDbFile();
 
 export const sequelize = new Sequelize({
   dialect: SqliteDialect,
   storage: DB_FILE,
-  logging: process.env.RESONANCE_DB_LOGGING === 'true' ? (msg) => logger.debug(msg) : false,
+  logging: process.env.DEEPCRATE_DB_LOGGING === 'true' ? (msg) => logger.debug(msg) : false,
   define:  {
     // All tables use snake_case column names in the database
     underscored: true,

--- a/server/src/config/logger.ts
+++ b/server/src/config/logger.ts
@@ -83,7 +83,7 @@ const logger = createLogger({
     format.splat(),
     format.json()
   ),
-  defaultMeta: { service: 'resonance' },
+  defaultMeta: { service: 'deepcrate' },
   transports:  [],
 });
 

--- a/server/src/config/settings.ts
+++ b/server/src/config/settings.ts
@@ -349,7 +349,7 @@ let cachedConfig: Config | null = null;
  * 3. ./config.yaml (local development)
  *
  * Environment variable overrides:
- * - RESONANCE_* env vars with __ for nesting (e.g., RESONANCE_UI__AUTH__ENABLED=true)
+ * - DEEPCRATE_* env vars with __ for nesting (e.g., DEEPCRATE_UI__AUTH__ENABLED=true)
  */
 export function loadConfig(): Config {
   if (cachedConfig) {
@@ -453,16 +453,16 @@ function resolveConfigPath(): string {
 }
 
 /**
- * Apply RESONANCE_* environment variable overrides to config object.
+ * Apply DEEPCRATE_* environment variable overrides to config object.
  * Uses __ as a separator for nested keys.
  *
  * Examples:
- * - RESONANCE_DEBUG=true -> { debug: true }
- * - RESONANCE_UI__AUTH__ENABLED=true -> { ui: { auth: { enabled: true } } }
- * - RESONANCE_SLSKD__HOST=http://localhost:5030 -> { slskd: { host: 'http://localhost:5030' } }
+ * - DEEPCRATE_DEBUG=true -> { debug: true }
+ * - DEEPCRATE_UI__AUTH__ENABLED=true -> { ui: { auth: { enabled: true } } }
+ * - DEEPCRATE_SLSKD__HOST=http://localhost:5030 -> { slskd: { host: 'http://localhost:5030' } }
  */
 function applyEnvOverrides(config: Record<string, unknown>): Record<string, unknown> {
-  const prefix = 'RESONANCE_';
+  const prefix = 'DEEPCRATE_';
 
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith(prefix) || value === undefined) {

--- a/server/src/controllers/HealthController.ts
+++ b/server/src/controllers/HealthController.ts
@@ -15,7 +15,7 @@ class HealthController extends BaseController {
     const response: HealthResponse = {
       status:  'ok',
       version: '1.0.0',
-      service: 'resonance',
+      service: 'deepcrate',
     };
 
     return res.json(response);

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,5 +1,5 @@
 /**
- * Model exports for Resonance
+ * Model exports for DeepCrate
  */
 
 export { default as QueueItem } from './QueueItem';

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -17,7 +17,7 @@ let server: http.Server | null = null;
 
 async function startServer(): Promise<void> {
   try {
-    logger.info('Starting Resonance server...');
+    logger.info('Starting DeepCrate server...');
 
     logger.info('Initializing database...');
     await initDb();
@@ -52,7 +52,7 @@ async function startServer(): Promise<void> {
     logger.info('Starting download progress sync...');
     startProgressSync();
 
-    logger.info('Resonance server started successfully');
+    logger.info('DeepCrate server started successfully');
   } catch(error) {
     logger.error('Failed to start server:', { error });
     process.exit(1);

--- a/server/src/services/clients/MusicBrainzClient.ts
+++ b/server/src/services/clients/MusicBrainzClient.ts
@@ -10,7 +10,7 @@ import type {
 import axios from 'axios';
 import logger from '@server/config/logger';
 
-const USER_AGENT = 'resonance/1.0 (music-discovery)';
+const USER_AGENT = 'deepcrate/1.0 (music-discovery)';
 const BASE_URL = 'https://musicbrainz.org/ws/2';
 
 /**

--- a/server/src/services/clients/SubsonicClient.ts
+++ b/server/src/services/clients/SubsonicClient.ts
@@ -54,7 +54,7 @@ export class SubsonicClient {
       t: token,
       s: salt,
       v: '1.16.1',
-      c: 'resonance',
+      c: 'deepcrate',
       f: 'json',
     };
 
@@ -126,7 +126,7 @@ export class SubsonicClient {
       t: token,
       s: salt,
       v: '1.16.1',
-      c: 'resonance',
+      c: 'deepcrate',
       f: 'json',
     };
 
@@ -219,7 +219,7 @@ export class SubsonicClient {
       t: token,
       s: salt,
       v: '1.16.1',
-      c: 'resonance',
+      c: 'deepcrate',
       f: 'json',
     };
 

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,5 +1,5 @@
 /**
- * Service exports for Resonance
+ * Service exports for DeepCrate
  */
 
 // Types

--- a/ui/MIGRATION.md
+++ b/ui/MIGRATION.md
@@ -12,7 +12,7 @@ This document describes the migration from Tailwind CSS v4 to PrimeVue 4, comple
 
 ### UI Framework
 - **Before:** Tailwind CSS v4 with custom utility classes
-- **After:** PrimeVue 4 with custom Resonance theme preset
+- **After:** PrimeVue 4 with custom DeepCrate theme preset
 - **Theme:** Custom indigo/purple color scheme maintained from Tailwind design
 
 ### Directory Structure
@@ -103,7 +103,7 @@ import { ROUTE_PATHS, ROUTE_NAMES } from '@/constants/routes'
 ### Phase 1: Foundation Setup ✅
 - Added PrimeVue, removed Tailwind dependencies
 - Created directory structure (composables, constants, pages, services, utils)
-- Created custom Resonance theme preset (indigo/purple colors)
+- Created custom DeepCrate theme preset (indigo/purple colors)
 - Added @ path alias configuration
 - Deleted Tailwind files
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,4 +1,4 @@
-# Resonance UI
+# DeepCrate UI
 
 Modern web UI for managing music discovery queue, built with Vue 3 and PrimeVue.
 
@@ -17,7 +17,7 @@ Modern web UI for managing music discovery queue, built with Vue 3 and PrimeVue.
 ```
 src/
 ├── assets/styles/      # Theme preset and global styles
-│   ├── theme.ts        # Custom Resonance PrimeVue theme preset
+│   ├── theme.ts        # Custom DeepCrate PrimeVue theme preset
 │   └── index.css       # Global CSS and utility classes
 ├── components/         # Reusable Vue components
 │   ├── common/         # Shared components (LoadingSpinner, StatsCard)
@@ -84,7 +84,7 @@ import type { QueueItem } from '@/types'
 
 ## Theme Customization
 
-The Resonance theme is defined in `src/assets/styles/theme.ts` using PrimeVue's preset system.
+The DeepCrate theme is defined in `src/assets/styles/theme.ts` using PrimeVue's preset system.
 
 ### Custom Colors
 
@@ -97,7 +97,7 @@ The Resonance theme is defined in `src/assets/styles/theme.ts` using PrimeVue's 
 Edit `src/assets/styles/theme.ts`:
 
 ```typescript
-export const ResonancePreset = definePreset(Aura, {
+export const DeepCratePreset = definePreset(Aura, {
   semantic: {
     primary: {
       50: '#eef2ff',   // Lightest indigo

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.ico" sizes="48x48">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Resonance</title>
+    <title>DeepCrate</title>
     <!-- Google Fonts: Space Grotesk (display) + Noto Sans (body) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resonance/ui",
+  "name": "@deepcrate/ui",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -55,7 +55,7 @@ function handleLogout(): void {
           />
         </div>
         <div class="sidebar__branding">
-          <span class="sidebar__title">Resonance</span>
+          <span class="sidebar__title">DeepCrate</span>
           <!-- TODO: Implement version number -->
            <!-- <span class="sidebar__version">v2.4.0</span>  -->
         </div>

--- a/ui/src/assets/styles/theme.ts
+++ b/ui/src/assets/styles/theme.ts
@@ -1,7 +1,7 @@
 import { definePreset } from '@primeuix/themes';
 import Aura from '@primeuix/themes/aura';
 
-export const ResonancePreset = definePreset(Aura, {
+export const DeepCratePreset = definePreset(Aura, {
   primitive: {
     borderRadius: {
       none: '0',

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -11,7 +11,7 @@ import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
 import Tooltip from 'primevue/tooltip';
 
-import { ResonancePreset } from '@/assets/styles/theme';
+import { DeepCratePreset } from '@/assets/styles/theme';
 import '@/assets/styles/index.css';
 import 'primeicons/primeicons.css';
 
@@ -26,7 +26,7 @@ useThemeStore(pinia).initialize();
 app.use(router);
 app.use(PrimeVue, {
   theme: {
-    preset:  ResonancePreset,
+    preset:  DeepCratePreset,
     options: {
       darkModeSelector: '.dark',
       cssLayer:         false,

--- a/ui/src/pages/private/SettingsPage.vue
+++ b/ui/src/pages/private/SettingsPage.vue
@@ -85,7 +85,7 @@ function handleUIPreferencesSave(prefs: Partial<UIPreferences>) {
       <div>
         <h1 class="settings-page__title">Settings</h1>
         <p class="settings-page__subtitle">
-          Configure your Resonance discovery pipeline preferences.
+          Configure your DeepCrate discovery pipeline preferences.
         </p>
       </div>
     </header>
@@ -167,7 +167,7 @@ function handleUIPreferencesSave(prefs: Partial<UIPreferences>) {
             <div class="settings-page__panel">
               <h2 class="settings-page__section-title">Authentication</h2>
               <p class="settings-page__section-desc">
-                Configure how users authenticate to access Resonance.
+                Configure how users authenticate to access DeepCrate.
               </p>
               <AuthForm
                 :settings="ui"
@@ -182,7 +182,7 @@ function handleUIPreferencesSave(prefs: Partial<UIPreferences>) {
             <div class="settings-page__panel">
               <h2 class="settings-page__section-title">UI Preferences</h2>
               <p class="settings-page__section-desc">
-                Customize the look and feel of the Resonance interface.
+                Customize the look and feel of the DeepCrate interface.
               </p>
               <UIPreferencesForm
                 :preferences="uiPreferences"

--- a/ui/src/pages/public/LoginPage.vue
+++ b/ui/src/pages/public/LoginPage.vue
@@ -93,7 +93,7 @@ async function handleApiKeySubmit() {
           width="100"
           height="100"
         />
-        <h1 class="text-2xl font-bold text-color">Resonance</h1>
+        <h1 class="text-2xl font-bold text-color">DeepCrate</h1>
         <p class="mt-2 text-muted">Sign in to manage your music queue</p>
       </div>
 

--- a/ui/src/stores/settings.ts
+++ b/ui/src/stores/settings.ts
@@ -10,7 +10,7 @@ import { ref, computed } from 'vue';
 import * as settingsApi from '@/services/settings';
 import { DEFAULT_UI_PREFERENCES } from '@/types/settings';
 
-const UI_PREFS_KEY = 'resonance_ui_prefs';
+const UI_PREFS_KEY = 'deepcrate_ui_prefs';
 
 export const useSettingsStore = defineStore('settings', () => {
   const settings = ref<SettingsResponse | null>(null);


### PR DESCRIPTION
Close #81 

- Rename all references across the entire codebase (37 files) including package names, Docker images, env var prefixes (`RESONANCE_` -> `DEEPCRATE_`), user-agent strings, service identifiers, documentation, and examples.
- Adds SQLite DB filename fallback: uses `deepcrate.sqlite` by default but auto-detects legacy `resonance.sqlite` with a deprecation warning.

---

## Resonance is being renamed to **DeepCrate**

- `v0.1.14` will be the final `resonance` release with DeepCrate code and deprecation note in release notes      
- `v0.1.15` will be the first `deepcrate` release under the new name

## What you need to update

### Docker image (required after this release)

```yaml
# Before
image: ghcr.io/jordojordo/resonance:latest

# After
image: ghcr.io/jordojordo/deepcrate:latest
```

### Container and service names (recommended)

```yaml
# Before
services:
resonance:
container_name: resonance

# After
services:
deepcrate:
container_name: deepcrate
```

### Network names (if using the combined/Authelia compose examples)

```yaml
# Before
resonance-net

# After
deepcrate-net
```

### Environment variable prefix (if using env var overrides)

```yaml
# Before
RESONANCE_SLSKD\_\_HOST=http://slskd:5030
RESONANCE_DB_FILE=/data/mydb.sqlite
RESONANCE_DB_LOGGING=true

# After
DEEPCRATE_SLSKD\_\_HOST=http://slskd:5030
DEEPCRATE_DB_FILE=/data/mydb.sqlite
DEEPCRATE_DB_LOGGING=true
```

### Database file (optional, handled automatically)

The default database filename has changed from `resonance.sqlite` to `deepcrate.sqlite`. No action is required, if `deepcrate.sqlite` doesn't exist but `resonance.sqlite` does, it will be used automatically. You'll see a deprecation warning in the logs prompting you to rename the file.

To migrate manually:

```bash
mv /data/resonance.sqlite /data/deepcrate.sqlite
```

This fallback will be removed in a future version.

## What you don't need to update

- `config.yaml`: no changes needed, the config format is unchanged
- **GitHub links**: the old repo URL will redirect automatically
