### PR TITLE
test(server): add integration tests for routes [#97, #98]

### DIFF
--- a/server/src/controllers/DownloadsController.test.ts
+++ b/server/src/controllers/DownloadsController.test.ts
@@ -1,0 +1,521 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import request from 'supertest';
+
+vi.mock('@server/config/settings', async(importOriginal) => {
+  const actual = await importOriginal<typeof import('@server/config/settings')>();
+
+  return { ...actual, getConfig: vi.fn().mockReturnValue({}) };
+});
+
+const mockService = vi.hoisted(() => ({
+  getActive:          vi.fn(),
+  getCompleted:       vi.fn(),
+  getFailed:          vi.fn(),
+  retry:              vi.fn(),
+  delete:             vi.fn(),
+  getStats:           vi.fn(),
+  getSearchResults:   vi.fn(),
+  selectSearchResult: vi.fn(),
+  skipSearchResult:   vi.fn(),
+  retrySearch:        vi.fn(),
+  autoSelectBest:     vi.fn(),
+}));
+
+vi.mock('@server/services/DownloadService', () => ({
+  DownloadService: class { constructor() { return mockService; } },
+}));
+
+vi.mock('@server/config/jobs', () => ({
+  JOB_INTERVALS:  {},
+  RUN_ON_STARTUP: false,
+  secondsToCron:  vi.fn(),
+}));
+
+vi.mock('@server/plugins/jobs', () => ({
+  triggerJob:     vi.fn(),
+  startJobs:      vi.fn(),
+  stopJobs:       vi.fn(),
+  getJobStatus:   vi.fn(),
+  cancelJob:      vi.fn(),
+  isJobCancelled: vi.fn(),
+}));
+
+import app from '@server/plugins/app';
+import { getConfig } from '@server/config/settings';
+import { AUTH_HEADER, AUTH_CONFIG } from '@server/tests/helpers/auth';
+
+const mockGetConfig = vi.mocked(getConfig);
+
+const TEST_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const TEST_UUID_2 = '550e8400-e29b-41d4-a716-446655440001';
+
+function makeActiveDownload(overrides: Record<string, unknown> = {}) {
+  return {
+    id:             TEST_UUID,
+    artist:         'Test Artist',
+    album:          'Test Album',
+    status:         'downloading',
+    progress:       45,
+    totalBytes:     1024000,
+    downloadedBytes: 460800,
+    speed:          512,
+    ...overrides,
+  };
+}
+
+function makeDownloadModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id:              TEST_UUID,
+    wishlistKey:     'test-artist-test-album',
+    artist:          'Test Artist',
+    album:           'Test Album',
+    type:            'album',
+    status:          'completed',
+    downloadPath:    '/downloads/Test Artist - Test Album',
+    slskdUsername:   'user123',
+    slskdDirectory:  '@@user123\\Music\\Test Album',
+    fileCount:       10,
+    errorMessage:    null,
+    retryCount:      0,
+    queuedAt:        '2025-01-15T12:00:00.000Z',
+    startedAt:       '2025-01-15T12:05:00.000Z',
+    completedAt:     '2025-01-15T12:10:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('DownloadsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReturnValue(AUTH_CONFIG as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Auth', () => {
+    it('returns 401 without auth header on a protected endpoint', async() => {
+      const response = await request(app).get('/api/v1/downloads/active');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'unauthorized',
+      });
+    });
+  });
+
+  describe('GET /api/v1/downloads/active', () => {
+    it('returns paginated active downloads', async() => {
+      const items = [makeActiveDownload()];
+
+      mockService.getActive.mockResolvedValue({ items, total: 1 });
+
+      const response = await request(app)
+        .get('/api/v1/downloads/active')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        items:  expect.any(Array),
+        total:  1,
+        limit:  50,
+        offset: 0,
+      });
+      expect(response.body.items).toHaveLength(1);
+      expect(mockService.getActive).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    });
+
+    it('accepts limit and offset params', async() => {
+      mockService.getActive.mockResolvedValue({ items: [], total: 0 });
+
+      const response = await request(app)
+        .get('/api/v1/downloads/active')
+        .query({ limit: 10, offset: 20 })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(mockService.getActive).toHaveBeenCalledWith({ limit: 10, offset: 20 });
+    });
+
+    it('returns 400 for invalid params', async() => {
+      const response = await request(app)
+        .get('/api/v1/downloads/active')
+        .query({ limit: -1 })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+  });
+
+  describe('GET /api/v1/downloads/completed', () => {
+    it('returns paginated completed downloads', async() => {
+      const items = [makeDownloadModel({ status: 'completed' })];
+
+      mockService.getCompleted.mockResolvedValue({ items, total: 1 });
+
+      const response = await request(app)
+        .get('/api/v1/downloads/completed')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        items:  expect.any(Array),
+        total:  1,
+        limit:  50,
+        offset: 0,
+      });
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0]).toMatchObject({
+        id:     TEST_UUID,
+        artist: 'Test Artist',
+        album:  'Test Album',
+        status: 'completed',
+      });
+    });
+
+    it('returns 500 on service error', async() => {
+      mockService.getCompleted.mockRejectedValue(new Error('DB failure'));
+
+      const response = await request(app)
+        .get('/api/v1/downloads/completed')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'internal_error',
+        message: 'Failed to fetch completed downloads',
+      });
+    });
+  });
+
+  describe('GET /api/v1/downloads/failed', () => {
+    it('returns paginated failed downloads', async() => {
+      const items = [makeDownloadModel({
+        status:       'failed',
+        errorMessage: 'Connection timeout',
+        completedAt:  null,
+      })];
+
+      mockService.getFailed.mockResolvedValue({ items, total: 1 });
+
+      const response = await request(app)
+        .get('/api/v1/downloads/failed')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        items:  expect.any(Array),
+        total:  1,
+        limit:  50,
+        offset: 0,
+      });
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0]).toMatchObject({
+        status:       'failed',
+        errorMessage: 'Connection timeout',
+      });
+    });
+  });
+
+  describe('POST /api/v1/downloads/retry', () => {
+    it('retries downloads by IDs', async() => {
+      mockService.retry.mockResolvedValue({ success: 2, failed: 0, failures: [] });
+
+      const response = await request(app)
+        .post('/api/v1/downloads/retry')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [TEST_UUID, TEST_UUID_2] });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success:  true,
+        count:    2,
+        message:  'Retried 2 downloads, 0 failed',
+        failures: [],
+      });
+      expect(mockService.retry).toHaveBeenCalledWith([TEST_UUID, TEST_UUID_2]);
+    });
+
+    it('returns 400 for invalid UUIDs', async() => {
+      const response = await request(app)
+        .post('/api/v1/downloads/retry')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: ['not-a-uuid'] });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+
+    it('returns 400 for empty array', async() => {
+      const response = await request(app)
+        .post('/api/v1/downloads/retry')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [] });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+  });
+
+  describe('DELETE /api/v1/downloads', () => {
+    it('deletes downloads by IDs', async() => {
+      mockService.delete.mockResolvedValue({ success: 1, failed: 0, failures: [] });
+
+      const response = await request(app)
+        .delete('/api/v1/downloads')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [TEST_UUID] });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success:  true,
+        count:    1,
+        message:  'Deleted 1 download(s)',
+        failures: [],
+      });
+      expect(mockService.delete).toHaveBeenCalledWith([TEST_UUID]);
+    });
+
+    it('returns 400 for empty array', async() => {
+      const response = await request(app)
+        .delete('/api/v1/downloads')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [] });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+  });
+
+  describe('GET /api/v1/downloads/stats', () => {
+    it('returns download stats', async() => {
+      const stats = {
+        active:         5,
+        queued:         3,
+        completed:      10,
+        failed:         2,
+        totalBandwidth: 1024,
+      };
+
+      mockService.getStats.mockResolvedValue(stats);
+
+      const response = await request(app)
+        .get('/api/v1/downloads/stats')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(stats);
+      expect(mockService.getStats).toHaveBeenCalled();
+    });
+
+    it('returns 500 on service error', async() => {
+      mockService.getStats.mockRejectedValue(new Error('Stats failure'));
+
+      const response = await request(app)
+        .get('/api/v1/downloads/stats')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'internal_error',
+        message: 'Failed to fetch download stats',
+      });
+    });
+  });
+
+  describe('GET /api/v1/downloads/:id/search-results', () => {
+    it('returns search results for a task', async() => {
+      const searchResults = {
+        id:      TEST_UUID,
+        results: [{ username: 'user1', files: 10 }],
+      };
+
+      mockService.getSearchResults.mockResolvedValue(searchResults);
+
+      const response = await request(app)
+        .get(`/api/v1/downloads/${ TEST_UUID }/search-results`)
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(searchResults);
+      expect(mockService.getSearchResults).toHaveBeenCalledWith(TEST_UUID);
+    });
+
+    it('returns 404 when task not found', async() => {
+      mockService.getSearchResults.mockResolvedValue(null);
+
+      const response = await request(app)
+        .get(`/api/v1/downloads/${ TEST_UUID }/search-results`)
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        success: false,
+        error:   'Task not found or not pending selection',
+      });
+    });
+  });
+
+  describe('POST /api/v1/downloads/:id/select', () => {
+    it('selects a search result successfully', async() => {
+      mockService.selectSearchResult.mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ username: 'user123', directory: '@@user123\\Music' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+      expect(mockService.selectSearchResult).toHaveBeenCalledWith(
+        TEST_UUID,
+        'user123',
+        '@@user123\\Music',
+      );
+    });
+
+    it('returns 400 for missing username', async() => {
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+
+    it('returns 404 when task not found', async() => {
+      mockService.selectSearchResult.mockResolvedValue({
+        success: false,
+        error:   'Task not found',
+      });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ username: 'user123' });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        success: false,
+        error:   'Task not found',
+      });
+    });
+
+    it('returns 410 when selection expired', async() => {
+      mockService.selectSearchResult.mockResolvedValue({
+        success: false,
+        error:   'Selection expired',
+      });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ username: 'user123' });
+
+      expect(response.status).toBe(410);
+      expect(response.body).toMatchObject({
+        success: false,
+        error:   'Selection expired',
+      });
+    });
+  });
+
+  describe('POST /api/v1/downloads/:id/skip', () => {
+    it('skips a search result', async() => {
+      mockService.skipSearchResult.mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/skip`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ username: 'user123' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+      expect(mockService.skipSearchResult).toHaveBeenCalledWith(TEST_UUID, 'user123');
+    });
+
+    it('returns 400 for missing username', async() => {
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/skip`)
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+  });
+
+  describe('POST /api/v1/downloads/:id/retry-search', () => {
+    it('retries search successfully', async() => {
+      mockService.retrySearch.mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/retry-search`)
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+      expect(mockService.retrySearch).toHaveBeenCalledWith(TEST_UUID, undefined);
+    });
+  });
+
+  describe('POST /api/v1/downloads/:id/auto-select', () => {
+    it('auto-selects the best result', async() => {
+      mockService.autoSelectBest.mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/auto-select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+      expect(mockService.autoSelectBest).toHaveBeenCalledWith(TEST_UUID);
+    });
+
+    it('returns 404 when task not found', async() => {
+      mockService.autoSelectBest.mockResolvedValue({
+        success: false,
+        error:   'Task not found',
+      });
+
+      const response = await request(app)
+        .post(`/api/v1/downloads/${ TEST_UUID }/auto-select`)
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        success: false,
+        error:   'Task not found',
+      });
+    });
+  });
+});

--- a/server/src/controllers/JobsController.test.ts
+++ b/server/src/controllers/JobsController.test.ts
@@ -1,0 +1,199 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import request from 'supertest';
+
+const mockGetConfig = vi.hoisted(() => vi.fn().mockReturnValue({
+  ui:                { auth: { enabled: false, type: 'basic' } },
+  slskd:             {},
+  library_organize:  {},
+  catalog_discovery: {},
+}));
+
+vi.mock('@server/config/settings', async(importOriginal) => {
+  const actual = await importOriginal<typeof import('@server/config/settings')>();
+
+  return { ...actual, getConfig: mockGetConfig };
+});
+
+vi.mock('@server/config/jobs', () => ({
+  JOB_INTERVALS:  {},
+  RUN_ON_STARTUP: false,
+  secondsToCron:  vi.fn(),
+}));
+
+const mockGetJobStatus = vi.hoisted(() => vi.fn());
+const mockTriggerJob = vi.hoisted(() => vi.fn());
+const mockCancelJob = vi.hoisted(() => vi.fn());
+
+vi.mock('@server/plugins/jobs', () => ({
+  getJobStatus:   mockGetJobStatus,
+  triggerJob:     mockTriggerJob,
+  cancelJob:      mockCancelJob,
+  startJobs:      vi.fn(),
+  stopJobs:       vi.fn(),
+  isJobCancelled: vi.fn(),
+}));
+
+import app from '@server/plugins/app';
+import { AUTH_HEADER, AUTH_CONFIG } from '@server/tests/helpers/auth';
+
+describe('JobsController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReturnValue(AUTH_CONFIG as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Auth', () => {
+    it('returns 401 without auth header on a protected endpoint', async() => {
+      const response = await request(app).get('/api/v1/jobs/status');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'unauthorized',
+      });
+    });
+  });
+
+  describe('GET /api/v1/jobs/status', () => {
+    it('returns job status array', async() => {
+      const jobs = [
+        {
+          name:    'listenbrainz-fetch',
+          cron:    '0 */6 * * *',
+          running: false,
+          lastRun: null,
+          nextRun: '2025-01-01T06:00:00.000Z',
+        },
+      ];
+
+      mockGetJobStatus.mockReturnValue(jobs);
+
+      const response = await request(app)
+        .get('/api/v1/jobs/status')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ jobs });
+      expect(mockGetJobStatus).toHaveBeenCalled();
+    });
+
+    it('returns 500 on error', async() => {
+      mockGetJobStatus.mockImplementation(() => {
+        throw new Error('Job status failure');
+      });
+
+      const response = await request(app)
+        .get('/api/v1/jobs/status')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'internal_error',
+        message: 'Failed to fetch job status',
+      });
+    });
+  });
+
+  describe('POST /api/v1/jobs/:jobName/trigger', () => {
+    it('triggers a job successfully', async() => {
+      mockTriggerJob.mockReturnValue(true);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/listenbrainz-fetch/trigger')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: "Job 'listenbrainz-fetch' triggered successfully",
+        jobName: 'listenbrainz-fetch',
+      });
+      expect(mockTriggerJob).toHaveBeenCalledWith('listenbrainz-fetch');
+    });
+
+    it('returns 409 when job is already running', async() => {
+      mockTriggerJob.mockReturnValue(false);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/listenbrainz-fetch/trigger')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(409);
+      expect(response.body).toEqual({
+        success: false,
+        message: "Job 'listenbrainz-fetch' is already running",
+        jobName: 'listenbrainz-fetch',
+      });
+    });
+
+    it('returns 404 when job is not found', async() => {
+      mockTriggerJob.mockReturnValue(null);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/nonexistent-job/trigger')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'not_found',
+        message: "Job 'nonexistent-job' not found",
+      });
+    });
+  });
+
+  describe('POST /api/v1/jobs/:jobName/cancel', () => {
+    it('cancels a running job successfully', async() => {
+      mockCancelJob.mockResolvedValue(true);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/listenbrainz-fetch/cancel')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: "Job 'listenbrainz-fetch' cancelled successfully",
+        jobName: 'listenbrainz-fetch',
+      });
+      expect(mockCancelJob).toHaveBeenCalledWith('listenbrainz-fetch');
+    });
+
+    it('returns 409 when job is not running', async() => {
+      mockCancelJob.mockResolvedValue(false);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/listenbrainz-fetch/cancel')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(409);
+      expect(response.body).toEqual({
+        success: false,
+        message: "Job 'listenbrainz-fetch' is not running",
+        jobName: 'listenbrainz-fetch',
+      });
+    });
+
+    it('returns 404 when job is not found', async() => {
+      mockCancelJob.mockResolvedValue(null);
+
+      const response = await request(app)
+        .post('/api/v1/jobs/nonexistent-job/cancel')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'not_found',
+        message: "Job 'nonexistent-job' not found",
+      });
+    });
+  });
+});

--- a/server/src/controllers/QueueController.test.ts
+++ b/server/src/controllers/QueueController.test.ts
@@ -1,0 +1,342 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import request from 'supertest';
+
+vi.mock('@server/config/settings', async(importOriginal) => {
+  const actual = await importOriginal<typeof import('@server/config/settings')>();
+
+  return {
+    ...actual,
+    getConfig: vi.fn().mockReturnValue({
+      ui:                { auth: { enabled: false } },
+      slskd:             {},
+      library_organize:  {},
+      catalog_discovery: {},
+    }),
+  };
+});
+
+const { mockService, mockTriggerJob } = vi.hoisted(() => ({
+  mockService: {
+    getPending:  vi.fn(),
+    approve:     vi.fn(),
+    approveAll:  vi.fn(),
+    reject:      vi.fn(),
+    getStats:    vi.fn(),
+  },
+  mockTriggerJob: vi.fn(),
+}));
+
+vi.mock('@server/services/QueueService', () => ({
+  QueueService: class { constructor() { return mockService; } },
+}));
+
+vi.mock('@server/config/jobs', () => ({
+  JOB_INTERVALS:  {},
+  RUN_ON_STARTUP: false,
+  secondsToCron:  vi.fn(),
+}));
+
+vi.mock('@server/plugins/jobs', () => ({
+  triggerJob:     mockTriggerJob,
+  startJobs:      vi.fn(),
+  stopJobs:       vi.fn(),
+  getJobStatus:   vi.fn(),
+  cancelJob:      vi.fn(),
+  isJobCancelled: vi.fn(),
+}));
+
+import app from '@server/plugins/app';
+import { getConfig } from '@server/config/settings';
+import { JOB_NAMES } from '@server/constants/jobs';
+import { AUTH_HEADER, AUTH_CONFIG } from '@server/tests/helpers/auth';
+
+const mockGetConfig = vi.mocked(getConfig);
+
+function makeMockItem(overrides: Record<string, unknown> = {}) {
+  return {
+    artist:      'Test Artist',
+    album:       'Test Album',
+    title:       null,
+    mbid:        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    type:        'album',
+    addedAt:     new Date('2025-01-15T12:00:00Z'),
+    score:       0.85,
+    source:      'listenbrainz',
+    similarTo:   ['Artist A', 'Artist B'],
+    sourceTrack: 'Some Track',
+    coverUrl:    'https://example.com/cover.jpg',
+    year:        2024,
+    inLibrary:   false,
+    ...overrides,
+  };
+}
+
+describe('QueueController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReturnValue(AUTH_CONFIG as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Auth', () => {
+    it('returns 401 without auth header on a protected endpoint', async() => {
+      const response = await request(app).get('/api/v1/queue/pending');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'unauthorized',
+      });
+    });
+  });
+
+  describe('GET /api/v1/queue/pending', () => {
+    it('returns paginated items with defaults', async() => {
+      const items = [makeMockItem(), makeMockItem({ mbid: 'ffffffff-0000-1111-2222-333333333333', artist: 'Another Artist' })];
+
+      mockService.getPending.mockResolvedValue({ items, total: 2 });
+
+      const response = await request(app)
+        .get('/api/v1/queue/pending')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        items:  expect.any(Array),
+        total:  2,
+        limit:  50,
+        offset: 0,
+      });
+      expect(response.body.items).toHaveLength(2);
+      expect(response.body.items[0]).toEqual({
+        artist:       'Test Artist',
+        album:        'Test Album',
+        title:        null,
+        mbid:         'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        type:         'album',
+        added_at:     '2025-01-15T12:00:00.000Z',
+        score:        0.85,
+        source:       'listenbrainz',
+        similar_to:   ['Artist A', 'Artist B'],
+        source_track: 'Some Track',
+        cover_url:    'https://example.com/cover.jpg',
+        year:         2024,
+        in_library:   false,
+      });
+
+      expect(mockService.getPending).toHaveBeenCalledWith({
+        source:        'all',
+        sort:          'added_at',
+        order:         'desc',
+        limit:         50,
+        offset:        0,
+        hideInLibrary: false,
+      });
+    });
+
+    it('passes filter params to the service', async() => {
+      mockService.getPending.mockResolvedValue({ items: [], total: 0 });
+
+      const response = await request(app)
+        .get('/api/v1/queue/pending')
+        .query({
+          source:          'catalog',
+          sort:            'score',
+          order:           'asc',
+          limit:           10,
+          offset:          20,
+          hide_in_library: 'true',
+        })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(mockService.getPending).toHaveBeenCalledWith({
+        source:        'catalog',
+        sort:          'score',
+        order:         'asc',
+        limit:         10,
+        offset:        20,
+        hideInLibrary: true,
+      });
+    });
+
+    it('returns 400 for invalid params', async() => {
+      const response = await request(app)
+        .get('/api/v1/queue/pending')
+        .query({ limit: -1 })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+
+    it('returns 500 on service error', async() => {
+      mockService.getPending.mockRejectedValue(new Error('DB failure'));
+
+      const response = await request(app)
+        .get('/api/v1/queue/pending')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'internal_error',
+        message: 'Failed to fetch pending items',
+      });
+    });
+  });
+
+  describe('POST /api/v1/queue/approve', () => {
+    it('approves by mbid array', async() => {
+      const mbids = ['mbid-1', 'mbid-2'];
+
+      mockService.approve.mockResolvedValue(2);
+
+      const response = await request(app)
+        .post('/api/v1/queue/approve')
+        .set('Authorization', AUTH_HEADER)
+        .send({ mbids });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success: true,
+        count:   2,
+        message: 'Approved 2 items',
+      });
+      expect(mockService.approve).toHaveBeenCalledWith(mbids);
+      expect(mockService.approveAll).not.toHaveBeenCalled();
+    });
+
+    it('approves all pending items', async() => {
+      mockService.approveAll.mockResolvedValue(5);
+
+      const response = await request(app)
+        .post('/api/v1/queue/approve')
+        .set('Authorization', AUTH_HEADER)
+        .send({ all: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success: true,
+        count:   5,
+        message: 'Approved all 5 pending items',
+      });
+      expect(mockService.approveAll).toHaveBeenCalled();
+      expect(mockService.approve).not.toHaveBeenCalled();
+    });
+
+    it('triggers slskd job when count > 0', async() => {
+      mockService.approve.mockResolvedValue(1);
+
+      await request(app)
+        .post('/api/v1/queue/approve')
+        .set('Authorization', AUTH_HEADER)
+        .send({ mbids: ['mbid-1'] });
+
+      expect(mockTriggerJob).toHaveBeenCalledWith(JOB_NAMES.SLSKD);
+    });
+
+    it('skips slskd job when count is 0', async() => {
+      mockService.approve.mockResolvedValue(0);
+
+      await request(app)
+        .post('/api/v1/queue/approve')
+        .set('Authorization', AUTH_HEADER)
+        .send({ mbids: ['non-existent'] });
+
+      expect(mockTriggerJob).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when neither mbids nor all provided', async() => {
+      const response = await request(app)
+        .post('/api/v1/queue/approve')
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+      expect(response.body.message).toContain("'mbids'");
+    });
+  });
+
+  describe('POST /api/v1/queue/reject', () => {
+    it('rejects by mbid array', async() => {
+      const mbids = ['mbid-1', 'mbid-2'];
+
+      mockService.reject.mockResolvedValue(2);
+
+      const response = await request(app)
+        .post('/api/v1/queue/reject')
+        .set('Authorization', AUTH_HEADER)
+        .send({ mbids });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        success: true,
+        count:   2,
+        message: 'Rejected 2 items',
+      });
+      expect(mockService.reject).toHaveBeenCalledWith(mbids);
+    });
+
+    it('returns 400 for missing mbids', async() => {
+      const response = await request(app)
+        .post('/api/v1/queue/reject')
+        .set('Authorization', AUTH_HEADER)
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: true,
+        code:  'validation_error',
+      });
+    });
+  });
+
+  describe('GET /api/v1/queue/stats', () => {
+    it('returns stats object', async() => {
+      const stats = {
+        pending:  10,
+        approved: 25,
+        rejected: 5,
+        total:    40,
+      };
+
+      mockService.getStats.mockResolvedValue(stats);
+
+      const response = await request(app)
+        .get('/api/v1/queue/stats')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(stats);
+      expect(mockService.getStats).toHaveBeenCalled();
+    });
+
+    it('returns 500 on service error', async() => {
+      mockService.getStats.mockRejectedValue(new Error('Stats failure'));
+
+      const response = await request(app)
+        .get('/api/v1/queue/stats')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error:   true,
+        code:    'internal_error',
+        message: 'Failed to fetch queue stats',
+      });
+    });
+  });
+});

--- a/server/src/controllers/WishlistController.test.ts
+++ b/server/src/controllers/WishlistController.test.ts
@@ -1,0 +1,414 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import request from 'supertest';
+
+const mockService = vi.hoisted(() => ({
+  getAll:                 vi.fn(),
+  append:                 vi.fn(),
+  removeById:             vi.fn(),
+  getPaginatedWithStatus: vi.fn(),
+  updateById:             vi.fn(),
+  bulkDelete:             vi.fn(),
+  bulkRequeue:            vi.fn(),
+  exportItems:            vi.fn(),
+  importItems:            vi.fn(),
+}));
+
+const mockGetConfig = vi.hoisted(() => vi.fn().mockReturnValue({
+  ui:                { auth: { enabled: false, type: 'basic' } },
+  slskd:             {},
+  library_organize:  {},
+  catalog_discovery: {},
+}));
+
+
+vi.mock('@server/services/WishlistService', () => {
+  class MockWishlistService {
+    constructor() { return mockService; }
+  }
+
+  return { WishlistService: MockWishlistService, default: MockWishlistService };
+});
+
+vi.mock('@server/config/settings', async(importOriginal) => {
+  const actual = await importOriginal<typeof import('@server/config/settings')>();
+
+  return { ...actual, getConfig: mockGetConfig };
+});
+
+vi.mock('@server/config/jobs', () => ({
+  JOB_INTERVALS:  {},
+  RUN_ON_STARTUP: false,
+  secondsToCron:  vi.fn(),
+}));
+
+vi.mock('@server/plugins/jobs', () => ({
+  triggerJob:     vi.fn(),
+  startJobs:      vi.fn(),
+  stopJobs:       vi.fn(),
+  getJobStatus:   vi.fn(),
+  cancelJob:      vi.fn(),
+  isJobCancelled: vi.fn(),
+}));
+
+
+import app from '@server/plugins/app';
+import { AUTH_HEADER, AUTH_CONFIG } from '@server/tests/helpers/auth';
+
+const TEST_ID  = '550e8400-e29b-41d4-a716-446655440000';
+const TEST_ID2 = '550e8400-e29b-41d4-a716-446655440001';
+
+const wishlistItem = {
+  id:          TEST_ID,
+  artist:      'Radiohead',
+  album:       'OK Computer',
+  type:        'album' as const,
+  year:        1997,
+  mbid:        'mbid-123',
+  source:      'manual' as const,
+  coverUrl:    null,
+  addedAt:     new Date().toISOString(),
+  processedAt: null,
+};
+
+describe('WishlistController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReturnValue(AUTH_CONFIG as any);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('GET /api/v1/wishlist', () => {
+    it('returns entries and total', async() => {
+      mockService.getAll.mockResolvedValue([wishlistItem]);
+
+      const res = await request(app)
+        .get('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.entries).toHaveLength(1);
+      expect(res.body.entries[0]).toMatchObject({
+        id:     TEST_ID,
+        artist: 'Radiohead',
+        title:  'OK Computer',
+        type:   'album',
+        year:   1997,
+      });
+    });
+
+    it('returns empty list', async() => {
+      mockService.getAll.mockResolvedValue([]);
+
+      const res = await request(app)
+        .get('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toEqual([]);
+      expect(res.body.total).toBe(0);
+    });
+
+    it('returns 500 on service error', async() => {
+      mockService.getAll.mockRejectedValue(new Error('DB failure'));
+
+      const res = await request(app)
+        .get('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('internal_error');
+    });
+  });
+
+  describe('POST /api/v1/wishlist', () => {
+    it('creates item and returns 201', async() => {
+      mockService.append.mockResolvedValue(wishlistItem);
+
+      const res = await request(app)
+        .post('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER)
+        .send({ artist: 'Radiohead', title: 'OK Computer', type: 'album', year: 1997 });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.entry.artist).toBe('Radiohead');
+      expect(res.body.entry.title).toBe('OK Computer');
+      expect(mockService.append).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'Radiohead',
+          album:  'OK Computer',
+          type:   'album',
+          source: 'manual',
+        }),
+      );
+    });
+
+    it('returns 400 when artist is missing', async() => {
+      const res = await request(app)
+        .post('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER)
+        .send({ title: 'OK Computer', type: 'album' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+
+    it('returns 400 when title is missing for album type', async() => {
+      const res = await request(app)
+        .post('/api/v1/wishlist')
+        .set('Authorization', AUTH_HEADER)
+        .send({ artist: 'Radiohead', title: '', type: 'album' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('GET /api/v1/wishlist/paginated', () => {
+    it('returns paginated results with filters', async() => {
+      mockService.getPaginatedWithStatus.mockResolvedValue({
+        items:  [wishlistItem],
+        total:  1,
+        limit:  20,
+        offset: 0,
+      });
+
+      const res = await request(app)
+        .get('/api/v1/wishlist/paginated')
+        .query({ source: 'manual', limit: 20, offset: 0 })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+      expect(res.body.limit).toBe(20);
+      expect(res.body.offset).toBe(0);
+      expect(mockService.getPaginatedWithStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'manual', limit: 20, offset: 0 }),
+      );
+    });
+
+    it('returns 400 for invalid query params', async() => {
+      const res = await request(app)
+        .get('/api/v1/wishlist/paginated')
+        .query({ limit: 999 })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('DELETE /api/v1/wishlist/:id', () => {
+    it('deletes item and returns success', async() => {
+      mockService.removeById.mockResolvedValue(true);
+
+      const res = await request(app)
+        .delete(`/api/v1/wishlist/${ TEST_ID }`)
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toBe('Removed from wishlist');
+      expect(mockService.removeById).toHaveBeenCalledWith(TEST_ID);
+    });
+
+    it('returns 404 when item not found', async() => {
+      mockService.removeById.mockResolvedValue(false);
+
+      const res = await request(app)
+        .delete(`/api/v1/wishlist/${ TEST_ID }`)
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('not_found');
+    });
+  });
+
+  describe('PUT /api/v1/wishlist/:id', () => {
+    it('updates item and returns success', async() => {
+      const updated = { ...wishlistItem, artist: 'Thom Yorke' };
+      mockService.updateById.mockResolvedValue(updated);
+
+      const res = await request(app)
+        .put(`/api/v1/wishlist/${ TEST_ID }`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ artist: 'Thom Yorke' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.entry.artist).toBe('Thom Yorke');
+      expect(mockService.updateById).toHaveBeenCalledWith(
+        TEST_ID,
+        expect.objectContaining({ artist: 'Thom Yorke' }),
+      );
+    });
+
+    it('returns 404 when item not found', async() => {
+      mockService.updateById.mockResolvedValue(null);
+
+      const res = await request(app)
+        .put(`/api/v1/wishlist/${ TEST_ID }`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ artist: 'Thom Yorke' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('not_found');
+    });
+
+    it('returns 400 for invalid body', async() => {
+      const res = await request(app)
+        .put(`/api/v1/wishlist/${ TEST_ID }`)
+        .set('Authorization', AUTH_HEADER)
+        .send({ artist: '' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('DELETE /api/v1/wishlist/bulk', () => {
+    it('bulk deletes items and returns affected count', async() => {
+      mockService.bulkDelete.mockResolvedValue(2);
+
+      const res = await request(app)
+        .delete('/api/v1/wishlist/bulk')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [TEST_ID, TEST_ID2] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.affected).toBe(2);
+      expect(mockService.bulkDelete).toHaveBeenCalledWith([TEST_ID, TEST_ID2]);
+    });
+
+    it('returns 400 for empty ids array', async() => {
+      const res = await request(app)
+        .delete('/api/v1/wishlist/bulk')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('POST /api/v1/wishlist/requeue', () => {
+    it('bulk requeues items and returns affected count', async() => {
+      mockService.bulkRequeue.mockResolvedValue(2);
+
+      const res = await request(app)
+        .post('/api/v1/wishlist/requeue')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [TEST_ID, TEST_ID2] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.affected).toBe(2);
+      expect(mockService.bulkRequeue).toHaveBeenCalledWith([TEST_ID, TEST_ID2]);
+    });
+
+    it('returns 400 for empty ids array', async() => {
+      const res = await request(app)
+        .post('/api/v1/wishlist/requeue')
+        .set('Authorization', AUTH_HEADER)
+        .send({ ids: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('GET /api/v1/wishlist/export', () => {
+    it('exports wishlist as JSON', async() => {
+      const exportContent = JSON.stringify([{ artist: 'Radiohead', title: 'OK Computer' }]);
+      mockService.exportItems.mockResolvedValue(exportContent);
+
+      const res = await request(app)
+        .get('/api/v1/wishlist/export')
+        .query({ format: 'json' })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.headers['content-disposition']).toBe('attachment; filename="wishlist.json"');
+      expect(mockService.exportItems).toHaveBeenCalledWith(
+        expect.objectContaining({ format: 'json' }),
+      );
+    });
+
+    it('returns 400 for invalid format', async() => {
+      const res = await request(app)
+        .get('/api/v1/wishlist/export')
+        .query({ format: 'csv' })
+        .set('Authorization', AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('POST /api/v1/wishlist/import', () => {
+    it('imports items and returns 200', async() => {
+      mockService.importItems.mockResolvedValue({
+        added:   1,
+        skipped: 0,
+        errors:  0,
+        results: [{ artist: 'Radiohead', title: 'OK Computer', status: 'added' }],
+      });
+
+      const res = await request(app)
+        .post('/api/v1/wishlist/import')
+        .set('Authorization', AUTH_HEADER)
+        .send({
+          items: [{ artist: 'Radiohead', title: 'OK Computer', type: 'album' }],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.added).toBe(1);
+      expect(res.body.errors).toBe(0);
+      expect(mockService.importItems).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ artist: 'Radiohead', title: 'OK Computer', type: 'album' }),
+        ]),
+      );
+    });
+
+    it('returns 400 for empty items array', async() => {
+      const res = await request(app)
+        .post('/api/v1/wishlist/import')
+        .set('Authorization', AUTH_HEADER)
+        .send({ items: [] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe(true);
+      expect(res.body.code).toBe('validation_error');
+    });
+  });
+
+  describe('Auth', () => {
+    it('returns 401 without auth header', async() => {
+      const res = await request(app)
+        .get('/api/v1/wishlist');
+
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/server/src/tests/helpers/auth.ts
+++ b/server/src/tests/helpers/auth.ts
@@ -1,0 +1,21 @@
+/**
+ * Each test file must independently vi.mock('@server/config/settings')
+ */
+
+export const AUTH_CREDENTIALS = {
+  username: 'testuser',
+  password: 'testpass',
+};
+
+export const AUTH_HEADER = `Basic ${ Buffer.from(`${ AUTH_CREDENTIALS.username }:${ AUTH_CREDENTIALS.password }`).toString('base64') }`;
+
+export const AUTH_CONFIG = {
+  ui: {
+    auth: {
+      enabled:  true,
+      type:     'basic' as const,
+      username: AUTH_CREDENTIALS.username,
+      password: AUTH_CREDENTIALS.password,
+    },
+  },
+};


### PR DESCRIPTION
Close #97
Close #98 

This will provide tests for the queue, wishlist, downloads, and jobs routes.