### PR TITLE
fix: add `APP_VERSION` to build arguments

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -55,5 +55,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: APP_VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ RUN pnpm --filter @deepcrate/server run build
 # =============================================================================
 FROM node:24-alpine AS production
 
+ARG APP_VERSION=dev
+
 WORKDIR /app
 
 # Make pnpm non-interactive
@@ -107,7 +109,8 @@ COPY --from=ui-builder /build/ui/dist ./static
 RUN apk del python3 make g++
 
 # Environment variables
-ENV NODE_ENV=production \
+ENV APP_VERSION=$APP_VERSION \
+    NODE_ENV=production \
     CONFIG_PATH=/config/config.yaml \
     DATA_PATH=/data \
     LOG_LEVEL=info \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ DeepCrate is a music discovery and download pipeline built as a Node.js/TypeScri
 flowchart TD
     subgraph container["DEEPCRATE CONTAINER"]
         subgraph process["Node.js Process"]
-            express["<b>Express Server</b><br/>HTTP :8080<br/>/api/v1/*<br/>/health<br/>static files"]
+            express["<b>Express Server</b><br/>HTTP :8080<br/>/api/v1/*<br/>static files"]
             socketio["<b>Socket.io</b><br/>WebSocket<br/>/queue<br/>/downloads<br/>/jobs"]
             cron["<b>node-cron</b><br/>Job Scheduler<br/>lb-fetch<br/>catalog-disc<br/>slskd-dl<br/>library-sync<br/>library-org"]
         end

--- a/server/src/controllers/HealthController.test.ts
+++ b/server/src/controllers/HealthController.test.ts
@@ -32,12 +32,7 @@ vi.mock('@server/plugins/jobs', () => ({
   isJobCancelled: vi.fn(),
 }));
 
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
 import app from '@server/plugins/app';
-
-const { version } = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
 
 describe('HealthController', () => {
   beforeEach(() => {
@@ -55,7 +50,7 @@ describe('HealthController', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         status:  'ok',
-        version,
+        version: 'dev',
         service: 'deepcrate',
       });
     });

--- a/server/src/controllers/HealthController.ts
+++ b/server/src/controllers/HealthController.ts
@@ -1,13 +1,10 @@
 import type { Request, Response } from 'express';
 import type { HealthResponse } from '@server/types/responses';
 
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
 import { BaseController } from '@server/controllers/BaseController';
 import logger from '@server/config/logger';
 
-const { version } = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8'));
+const version = process.env.APP_VERSION ?? 'dev';
 
 /**
  * Health check controller

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -65,7 +65,9 @@ function handleLogout(): void {
         </div>
         <div class="sidebar__branding">
           <span class="sidebar__title">DeepCrate</span>
-          <span v-if="appVersion" class="sidebar__version">v{{ appVersion }}</span>
+          <span v-if="appVersion && appVersion !== 'dev'" class="sidebar__version">
+            {{ `v${ appVersion }` }}
+          </span>
         </div>
       </RouterLink>
     </template>


### PR DESCRIPTION
This will add a build argument `APP_VERSION` to remove the dependency on getting the version number from `package.json`. It will be `dev` by default, and not shown to the user.