### PR TITLE
fix(ui): use deprecated copy for insecure clipboard access

### DIFF
--- a/ui/src/composables/useCopyToClipboard.ts
+++ b/ui/src/composables/useCopyToClipboard.ts
@@ -11,8 +11,26 @@ export async function copyToClipboard(
   try {
     await navigator.clipboard.writeText(value);
     toast.showSuccess('Copied to clipboard');
-  } catch(error) {
-    toast.showError('Failed to copy to clipboard');
-    throw error;
+  } catch {
+    try {
+      fallbackCopy(value);
+      toast.showSuccess('Copied to clipboard');
+      console.warn('Copied using the deprecated method (`document.execCommand()`). Use HTTPS for reliable clipboard access.');
+    } catch(error) {
+      toast.showError('Failed to copy to clipboard');
+      throw error;
+    }
   }
+}
+
+function fallbackCopy(text: string): void {
+  const textarea = document.createElement('textarea');
+
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
 }


### PR DESCRIPTION
When attempting to copy text to the clipboard and DeepCrate is hosted on an insecure server, the clipboard copying will fail due to the `navigator.clipboard` object being undefined.

This will add a fallback to the deprecated [`document.execCommand`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) method which is the only option for HTTP.

> [!NOTE]
> This should go without saying, but unless you're running DeepCrate without publishing it to the world, you should be absolutely using HTTPS.