### PR TITLE
refactor(build): remove unnecessary layers to reduce build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,23 +48,19 @@ ARG APP_VERSION=dev
 WORKDIR /app
 ENV CI=true
 
-RUN corepack enable
-RUN apk add --no-cache curl su-exec python3 make g++ sqlite-dev
+RUN corepack enable && apk add --no-cache curl su-exec
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY server/package.json ./server/
 COPY ui/package.json ./ui/
 
-RUN pnpm --filter @deepcrate/server install --prod --frozen-lockfile
+RUN pnpm --filter @deepcrate/server install --prod --frozen-lockfile --ignore-scripts
 
-RUN cd /app/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3 && \
-    npm run install && \
-    ls -la build/ && \
-    echo "SQLite3 production build complete"
-
+COPY --from=server-builder \
+    /build/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/build/ \
+    /app/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/build/
 COPY --from=server-builder /build/server/dist ./server/dist
 COPY --from=ui-builder /build/ui/dist ./static
-RUN apk del python3 make g++
 
 ENV APP_VERSION=$APP_VERSION \
     NODE_ENV=production \
@@ -85,8 +81,7 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
 
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server/dist/server.js"]


### PR DESCRIPTION
This removes some unnecessary crud from the Dockerfile which adds a layer that should've been cleaned up:

```zsh
› docker history deepcrate:new   
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
3f2a26cb3205   3 minutes ago   CMD ["node" "server/dist/server.js"]            0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c chmod +x /…   700B      buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY docker-entrypoint.sh /usr/local/bin/ # …   700B      buildkit.dockerfile.v0
<missing>      3 minutes ago   HEALTHCHECK &{["CMD-SHELL" "curl -f http://l…   0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   EXPOSE [8080/tcp]                               0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c mkdir -p /…   0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   ENV APP_VERSION=dev NODE_ENV=production CONF…   0B        buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY /build/ui/dist ./static # buildkit         2.08MB    buildkit.dockerfile.v0
<missing>      3 minutes ago   COPY /build/server/dist ./server/dist # buil…   581kB     buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY /build/node_modules/.pnpm/sqlite3@5.1.7…   2.3MB     buildkit.dockerfile.v0
<missing>      5 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c pnpm --fil…   65.9MB    buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY ui/package.json ./ui/ # buildkit           1.42kB    buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY server/package.json ./server/ # buildkit   2.04kB    buildkit.dockerfile.v0
<missing>      5 minutes ago   COPY pnpm-workspace.yaml pnpm-lock.yaml pack…   248kB     buildkit.dockerfile.v0
<missing>      5 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c apk add --…   5.46MB    buildkit.dockerfile.v0
<missing>      2 weeks ago     RUN |1 APP_VERSION=dev /bin/sh -c corepack e…   140kB     buildkit.dockerfile.v0
<missing>      2 weeks ago     ENV CI=true                                     0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     WORKDIR /app                                    0B        buildkit.dockerfile.v0
<missing>      2 weeks ago     ARG APP_VERSION=dev                             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     COPY docker-entrypoint.sh /usr/local/bin/ # …   388B      buildkit.dockerfile.v0
<missing>      3 weeks ago     RUN /bin/sh -c apk add --no-cache --virtual …   5.36MB    buildkit.dockerfile.v0
<missing>      3 weeks ago     ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     RUN /bin/sh -c addgroup -g 1000 node     && …   145MB     buildkit.dockerfile.v0
<missing>      3 weeks ago     ENV NODE_VERSION=24.14.0                        0B        buildkit.dockerfile.v0
<missing>      7 weeks ago     CMD ["/bin/sh"]                                 0B        buildkit.dockerfile.v0
<missing>      7 weeks ago     ADD alpine-minirootfs-3.23.3-x86_64.tar.gz /…   8.44MB    buildkit.dockerfile.v0

› docker image inspect deepcrate:new --format='{{.Size}}'                      
235775481

› docker history deepcrate:old
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
c2607bfb9447   23 minutes ago   CMD ["node" "server/dist/server.js"]            0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c chmod +x /…   700B      buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY docker-entrypoint.sh /usr/local/bin/ # …   700B      buildkit.dockerfile.v0
<missing>      23 minutes ago   HEALTHCHECK &{["CMD-SHELL" "curl -f http://l…   0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   EXPOSE [8080/tcp]                               0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c mkdir -p /…   0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   ENV APP_VERSION=dev NODE_ENV=production CONF…   0B        buildkit.dockerfile.v0
<missing>      23 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c apk del py…   38.6kB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY /build/ui/dist ./static # buildkit         2.08MB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY /build/server/dist ./server/dist # buil…   581kB     buildkit.dockerfile.v0
<missing>      23 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c cd /app/no…   293kB     buildkit.dockerfile.v0
<missing>      23 minutes ago   RUN |1 APP_VERSION=dev /bin/sh -c pnpm --fil…   71.6MB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY ui/package.json ./ui/ # buildkit           1.42kB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY server/package.json ./server/ # buildkit   2.04kB    buildkit.dockerfile.v0
<missing>      23 minutes ago   COPY pnpm-workspace.yaml pnpm-lock.yaml pack…   248kB     buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN |1 APP_VERSION=dev /bin/sh -c apk add --…   312MB     buildkit.dockerfile.v0
<missing>      2 weeks ago      RUN |1 APP_VERSION=dev /bin/sh -c corepack e…   140kB     buildkit.dockerfile.v0
<missing>      2 weeks ago      ENV CI=true                                     0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      WORKDIR /app                                    0B        buildkit.dockerfile.v0
<missing>      2 weeks ago      ARG APP_VERSION=dev                             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      COPY docker-entrypoint.sh /usr/local/bin/ # …   388B      buildkit.dockerfile.v0
<missing>      3 weeks ago      RUN /bin/sh -c apk add --no-cache --virtual …   5.36MB    buildkit.dockerfile.v0
<missing>      3 weeks ago      ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago      RUN /bin/sh -c addgroup -g 1000 node     && …   145MB     buildkit.dockerfile.v0
<missing>      3 weeks ago      ENV NODE_VERSION=24.14.0                        0B        buildkit.dockerfile.v0
<missing>      7 weeks ago      CMD ["/bin/sh"]                                 0B        buildkit.dockerfile.v0
<missing>      7 weeks ago      ADD alpine-minirootfs-3.23.3-x86_64.tar.gz /…   8.44MB    buildkit.dockerfile.v0

› docker image inspect deepcrate:old --format='{{.Size}}'   
546230649

```