### PR TITLE
feat(ui): add docs and github links to navigation

### DIFF
--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
 onlyBuiltDependencies:
   - esbuild

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,7 +7,7 @@ import { useSidebarItems } from '@/composables/useSidebarItems';
 import { useToast } from '@/composables/useToast';
 import { setToastCallback } from '@/services/api';
 import { fetchHealth } from '@/services/health';
-import { ROUTE_PATHS } from '@/constants/routes';
+import { EXTERNAL_URLS, ROUTE_PATHS } from '@/constants/routes';
 
 import Button from 'primevue/button';
 import Toast from 'primevue/toast';
@@ -74,6 +74,28 @@ function handleLogout(): void {
 
     <template #header-right>
       <Button
+        v-tooltip.bottom="'Documentation'"
+        as="a"
+        :href="EXTERNAL_URLS.DOCS_SITE"
+        target="_blank"
+        class="sidebar__header-button"
+        rel="noopener noreferrer"
+        aria-label="Documentation"
+        size="small"
+        icon="pi pi-book"
+      />
+      <Button
+        v-tooltip.bottom="'API reference'"
+        as="a"
+        :href="EXTERNAL_URLS.API_DOCS"
+        target="_blank"
+        class="sidebar__header-button"
+        rel="noopener noreferrer"
+        aria-label="API reference"
+        size="small"
+        icon="pi pi-code"
+      />
+      <Button
         v-if="requiresLogin && isAuthed"
         appearance="secondary"
         size="small"
@@ -136,6 +158,10 @@ function handleLogout(): void {
     color: var(--surface-400, #9d9db9);
     font-weight: 500;
     letter-spacing: 0.025em;
+  }
+
+  &__header-button {
+    text-decoration: none;
   }
 }
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -97,16 +97,32 @@ function handleLogout(): void {
       />
       <Button
         v-if="requiresLogin && isAuthed"
+        v-tooltip.bottom="'Logout'"
         appearance="secondary"
         size="small"
+        icon="pi pi-sign-out"
+        aria-label="Logout"
         @click="handleLogout"
-      >
-        Logout
-      </Button>
+      />
     </template>
 
     <template #sidebar-footer="{ sidebarCollapsed }">
-      <ThemeToggle :collapsed="sidebarCollapsed" />
+      <div class="sidebar__footer" :class="{ 'sidebar__footer--collapsed': sidebarCollapsed }">
+        <ThemeToggle :collapsed="sidebarCollapsed" />
+        <Button
+          v-tooltip.top="'DeepCrate repo'"
+          as="a"
+          :href="EXTERNAL_URLS.GITHUB"
+          target="_blank"
+          class="sidebar__footer-button"
+          severity="secondary"
+          text
+          rel="noopener noreferrer"
+          aria-label="Github repo"
+          size="small"
+          icon="pi pi-github"
+        />
+      </div>
     </template>
 
     <router-view />
@@ -160,8 +176,29 @@ function handleLogout(): void {
     letter-spacing: 0.025em;
   }
 
+  &__footer {
+    display: flex;
+    gap: 1rem;
+
+    &--collapsed {
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+
   &__header-button {
     text-decoration: none;
+  }
+
+  &__footer-button {
+    text-decoration: none;
+    color: var(--surface-300);
+    transition: background-color 0.2s ease, color 0.2s ease;
+
+    &:hover {
+      background-color: var(--r-hover-bg);
+      color: var(--r-text-primary);
+    }
   }
 }
 </style>

--- a/ui/src/constants/routes.ts
+++ b/ui/src/constants/routes.ts
@@ -21,4 +21,5 @@ export const ROUTE_NAMES = {
 export const EXTERNAL_URLS = {
   DOCS_SITE: 'https://jordojordo.github.io/deepcrate/',
   API_DOCS:  '/api/v1/docs',
+  GITHUB:    'https://github.com/jordojordo/deepcrate',
 } as const;

--- a/ui/src/constants/routes.ts
+++ b/ui/src/constants/routes.ts
@@ -17,3 +17,8 @@ export const ROUTE_NAMES = {
   SETTINGS:  'settings',
   LOGIN:     'login',
 } as const;
+
+export const EXTERNAL_URLS = {
+  DOCS_SITE: 'https://jordojordo.github.io/deepcrate/',
+  API_DOCS:  '/api/v1/docs',
+} as const;

--- a/ui/src/stores/theme.ts
+++ b/ui/src/stores/theme.ts
@@ -11,7 +11,7 @@ export const useThemeStore = defineStore('theme', () => {
 
   const systemPrefersDark = ref(true);
 
-  const mode = computed({
+  const mode = computed<ThemeMode>({
     get: () => uiPreferences.value.theme,
     set: (newMode: ThemeMode) => {
       settingsStore.saveUIPreferences({ theme: newMode });


### PR DESCRIPTION
Close #195 

This will add both the external (https://jordojordo.github.io/deepcrate) and internal (`/api/v1/docs`) docs as links in the top navigation, as well as a link to the deepcrate repo next to the theme toggle.