### PR TITLE
fix(server): skip compilation albums if possible

### DIFF
--- a/server/src/services/clients/MusicBrainzClient.test.ts
+++ b/server/src/services/clients/MusicBrainzClient.test.ts
@@ -152,6 +152,77 @@ describe('MusicBrainzClient', () => {
     });
   });
 
+  describe('resolveRecordingToAlbum', () => {
+    it('skips VA compilations and resolves to the studio album', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      vi.mocked(fetchJson).mockResolvedValueOnce({
+        data: {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [
+            {
+              'id':            'comp-release',
+              'title':         'Greatest Hits Compilation',
+              'release-group': {
+                'id':              'comp-rg-mbid',
+                'title':           'Greatest Hits Compilation',
+                'primary-type':    'Album',
+                'secondary-types': ['Compilation'],
+              },
+            },
+            {
+              'id':            'album-release',
+              'title':         'Test Album',
+              'release-group': {
+                'id':           'album-rg-mbid',
+                'title':        'Test Album',
+                'primary-type': 'Album',
+              },
+            },
+          ],
+        },
+        status: 200,
+      });
+
+      const result = await client.resolveRecordingToAlbum(recordingMbid);
+
+      expect(result?.mbid).toBe('album-rg-mbid');
+      expect(result?.title).toBe('Test Album');
+    });
+
+    it('falls back to a compilation when it is the only album', async() => {
+      const recordingMbid = 'test-recording-mbid';
+
+      vi.mocked(fetchJson).mockResolvedValueOnce({
+        data: {
+          'id':            recordingMbid,
+          'title':         'Test Track',
+          'artist-credit': [{ artist: { name: 'Test Artist' } }],
+          'releases':      [
+            {
+              'id':            'comp-release',
+              'title':         'Various Artists Compilation',
+              'release-group': {
+                'id':              'comp-rg-mbid',
+                'title':           'Various Artists Compilation',
+                'primary-type':    'Album',
+                'secondary-types': ['Compilation'],
+              },
+            },
+          ],
+        },
+        status: 200,
+      });
+
+      const result = await client.resolveRecordingToAlbum(recordingMbid);
+
+      expect(result?.mbid).toBe('comp-rg-mbid');
+      expect(result?.title).toBe('Various Artists Compilation');
+    });
+  });
+
   describe('getExpectedTrackCount', () => {
     it('returns track count from a single release', async() => {
       vi.mocked(fetchJson).mockResolvedValueOnce({

--- a/server/src/services/clients/MusicBrainzClient.ts
+++ b/server/src/services/clients/MusicBrainzClient.ts
@@ -143,19 +143,24 @@ export class MusicBrainzClient extends BaseClient {
         return null;
       }
 
-      // Prefer official albums over singles/EPs/compilations
+      // Prefer official albums over singles/EPs/compilations.
+      // VA compilations are typed primary-type "Album" + secondary-types
+      // ["Compilation"], skip those first to favor the artist's own album.
       let albumRelease = null;
 
       for (const release of releases) {
-        if (release['release-group']?.['primary-type'] === 'Album') {
+        const rg = release['release-group'];
+
+        if (rg?.['primary-type'] === 'Album' && !(rg['secondary-types'] || []).includes('Compilation')) {
           albumRelease = release;
           break;
         }
       }
 
-      // Fall back to first release if no album found
+      // Fall back to any album (including compilations) if no studio album exists,
+      // then to the first release of any type.
       if (!albumRelease) {
-        albumRelease = releases[0];
+        albumRelease = releases.find((r) => r['release-group']?.['primary-type'] === 'Album') ?? releases[0];
       }
 
       const rg = albumRelease['release-group'];

--- a/server/src/types/musicbrainz.ts
+++ b/server/src/types/musicbrainz.ts
@@ -55,6 +55,7 @@ interface MBReleaseGroupRef {
   id:                    string;
   title:                 string;
   'primary-type'?:       string;
+  'secondary-types'?:    string[];
   'first-release-date'?: string;
 }
 


### PR DESCRIPTION
Fix #191 

This will fix an issue where the "Hide Owned" filter in the queue list would miss "Various Artists" compilations. If a studio album can't be found it will fall back to the compilation.