### PR TITLE
feat: add lossless quality preference settings

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -125,6 +125,11 @@ slskd:
       prefer_lossless: true       # Give lossless formats higher priority
       reject_low_quality: false   # Hard reject files below min_bitrate (vs just deprioritize)
       reject_lossless: false      # Hard reject lossless files (for users who only want lossy)
+      # Lossless quality caps. 0 = unlimited. Files with unknown bit depth /
+      # sample rate are never rejected by these caps.
+      max_lossless_bit_depth: 16        # Max lossless bit depth (e.g. 16 = CD quality)
+      max_lossless_sample_rate: 44100   # Max lossless sample rate in Hz (e.g. 44100 = CD quality)
+      reject_high_res_lossless: true    # Hard reject lossless above the caps (vs just deprioritize)
 
     # Completeness scoring (optional)
     # Score results based on track completeness using MusicBrainz/Deezer metadata
@@ -411,6 +416,9 @@ Optional quality preferences configuration under `slskd.search.quality_preferenc
 | `prefer_lossless` | bool | `true` | Give lossless formats higher priority in scoring |
 | `reject_low_quality` | bool | `false` | Hard reject files below min_bitrate (vs just deprioritize) |
 | `reject_lossless` | bool | `false` | Hard reject lossless files (for users who only want lossy formats) |
+| `max_lossless_bit_depth` | int | `0` | Maximum accepted lossless bit depth (`0` = unlimited, e.g. `16` for CD quality) |
+| `max_lossless_sample_rate` | int | `0` | Maximum accepted lossless sample rate in Hz (`0` = unlimited, e.g. `44100` for CD quality) |
+| `reject_high_res_lossless` | bool | `false` | Hard reject lossless files above the caps (vs just deprioritize) |
 
 **Quality Tiers:**
 - **Lossless** - FLAC, WAV, ALAC, AIFF (highest priority by default)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -125,6 +125,11 @@ slskd:
       prefer_lossless: true       # Give lossless formats higher priority
       reject_low_quality: false   # Hard reject files below min_bitrate (vs just deprioritize)
       reject_lossless: false      # Hard reject lossless files (for users who only want lossy)
+      # Lossless quality caps. 0 = unlimited. Files with unknown bit depth /
+      # sample rate are never rejected by these caps.
+      max_lossless_bit_depth: 16        # Max lossless bit depth (e.g. 16 = CD quality)
+      max_lossless_sample_rate: 44100   # Max lossless sample rate in Hz (e.g. 44100 = CD quality)
+      reject_high_res_lossless: true    # Hard reject lossless above the caps (vs just deprioritize)
 
     # Completeness scoring (optional)
     # Score results based on track completeness using MusicBrainz/Deezer metadata

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,8 @@ packages:
   - docs
 
 allowBuilds:
-  '@parcel/watcher': true
-  esbuild: true
+  '@parcel/watcher': false
+  esbuild: false
   sqlite3: true
 
 overrides:

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -91,9 +91,15 @@ const SlskdQualityPreferencesSchema = z.object({
   preferred_formats:  z.array(z.string()).default([...DEFAULT_PREFERRED_FORMATS]),
   min_bitrate:        z.number().int().min(0).max(9999)
     .default(256),
-  prefer_lossless:    z.boolean().default(true),
-  reject_low_quality: z.boolean().default(false),
-  reject_lossless:    z.boolean().default(false),
+  prefer_lossless:        z.boolean().default(true),
+  reject_low_quality:     z.boolean().default(false),
+  reject_lossless:        z.boolean().default(false),
+  // Maximum accepted lossless quality (0 = unlimited). Files with unknown
+  // bit depth / sample rate are never rejected by these caps.
+  max_lossless_bit_depth:   z.number().int().min(0).max(32)
+    .default(0),
+  max_lossless_sample_rate: z.number().int().min(0).default(0),
+  reject_high_res_lossless: z.boolean().default(false),
 });
 
 const SlskdCompletenessSchema = z.object({

--- a/server/src/constants/slskd.ts
+++ b/server/src/constants/slskd.ts
@@ -47,6 +47,13 @@ export const QUALITY_SCORES = {
 /** Default preferred audio formats for quality filtering */
 export const DEFAULT_PREFERRED_FORMATS = ['flac', 'wav', 'alac', 'mp3', 'm4a', 'ogg'] as const;
 
+/**
+ * Score penalty applied to lossless files that exceed the configured
+ * max lossless quality cap. Sized to cancel the prefer_lossless bonus (500)
+ * so over-cap files rank below compliant lossless when not hard-rejected.
+ */
+export const LOSSLESS_OVER_CAP_PENALTY = 500;
+
 /** Quality tier order from highest to lowest quality */
 export const QUALITY_TIER_ORDER = ['lossless', 'high', 'standard', 'low', 'unknown'] as const;
 

--- a/server/src/openapi/schemas.ts
+++ b/server/src/openapi/schemas.ts
@@ -133,6 +133,32 @@ registry.register('ActivityItem', activityItemSchema);
 
 // --- Settings schemas ---
 
+// Documents the shape of `slskd.search.quality_preferences`, which is otherwise
+// carried as an opaque object inside the settings response. Registered as a
+// standalone component so the fields surface in the API reference.
+const slskdQualityPreferencesSchema = z.object({
+  enabled: z.boolean()
+    .openapi({ description: 'Enable quality-based filtering and scoring', example: true }),
+  preferred_formats: z.array(z.string())
+    .openapi({ description: 'Formats to prioritize (bonus scoring)', example: ['flac', 'wav', 'alac', 'mp3', 'm4a', 'ogg'] }),
+  min_bitrate: z.number().int()
+    .openapi({ description: 'Minimum acceptable bitrate (kbps) for lossy formats', example: 256 }),
+  prefer_lossless: z.boolean()
+    .openapi({ description: 'Give lossless formats higher priority in scoring', example: true }),
+  reject_low_quality: z.boolean()
+    .openapi({ description: 'Hard reject files below min_bitrate (vs just deprioritize)', example: false }),
+  reject_lossless: z.boolean()
+    .openapi({ description: 'Hard reject lossless files (for users who only want lossy formats)', example: false }),
+  max_lossless_bit_depth: z.number().int()
+    .openapi({ description: 'Maximum accepted lossless bit depth (0 = unlimited, e.g. 16 for CD quality). Files with unknown bit depth are never rejected.', example: 16 }),
+  max_lossless_sample_rate: z.number().int()
+    .openapi({ description: 'Maximum accepted lossless sample rate in Hz (0 = unlimited, e.g. 44100 for CD quality). Files with unknown sample rate are never rejected.', example: 44100 }),
+  reject_high_res_lossless: z.boolean()
+    .openapi({ description: 'Hard reject lossless files above the caps (vs just deprioritize)', example: false }),
+});
+
+registry.register('SlskdQualityPreferences', slskdQualityPreferencesSchema);
+
 registry.register('GetSettingsResponse', GetSettingsResponseSchema);
 registry.register('GetSectionResponse', GetSectionResponseSchema);
 registry.register('UpdateSectionResponse', UpdateSectionResponseSchema);

--- a/server/src/services/downloads/qualityPrefsBuilder.test.ts
+++ b/server/src/services/downloads/qualityPrefsBuilder.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildQualityPreferences } from './qualityPrefsBuilder';
+
+describe('buildQualityPreferences', () => {
+  it('returns undefined when no config is provided', () => {
+    expect(buildQualityPreferences()).toBeUndefined();
+  });
+
+  it('maps the lossless cap fields from config', () => {
+    const prefs = buildQualityPreferences({
+      enabled:                  true,
+      max_lossless_bit_depth:   16,
+      max_lossless_sample_rate: 44100,
+      reject_high_res_lossless: true,
+    });
+
+    expect(prefs).toMatchObject({
+      maxLosslessBitDepth:   16,
+      maxLosslessSampleRate: 44100,
+      rejectHighResLossless: true,
+    });
+  });
+
+  it('defaults the lossless cap fields to unlimited / off when absent', () => {
+    const prefs = buildQualityPreferences({ enabled: true });
+
+    expect(prefs).toMatchObject({
+      maxLosslessBitDepth:   0,
+      maxLosslessSampleRate: 0,
+      rejectHighResLossless: false,
+    });
+  });
+});

--- a/server/src/services/downloads/qualityPrefsBuilder.ts
+++ b/server/src/services/downloads/qualityPrefsBuilder.ts
@@ -8,12 +8,15 @@ import { DEFAULT_PREFERRED_FORMATS } from '@server/constants/slskd';
  */
 export function buildQualityPreferences(
   configPrefs?: {
-    enabled?:            boolean;
-    preferred_formats?:  string[];
-    min_bitrate?:        number;
-    prefer_lossless?:    boolean;
-    reject_low_quality?: boolean;
-    reject_lossless?:    boolean;
+    enabled?:                  boolean;
+    preferred_formats?:        string[];
+    min_bitrate?:              number;
+    prefer_lossless?:          boolean;
+    reject_low_quality?:       boolean;
+    reject_lossless?:          boolean;
+    max_lossless_bit_depth?:   number;
+    max_lossless_sample_rate?: number;
+    reject_high_res_lossless?: boolean;
   }
 ): QualityPreferences | undefined {
   if (!configPrefs) {
@@ -21,11 +24,14 @@ export function buildQualityPreferences(
   }
 
   return {
-    enabled:          configPrefs.enabled ?? true,
-    preferredFormats: configPrefs.preferred_formats ?? [...DEFAULT_PREFERRED_FORMATS],
-    minBitrate:       configPrefs.min_bitrate ?? 256,
-    preferLossless:   configPrefs.prefer_lossless ?? true,
-    rejectLowQuality: configPrefs.reject_low_quality ?? false,
-    rejectLossless:   configPrefs.reject_lossless ?? false,
+    enabled:               configPrefs.enabled ?? true,
+    preferredFormats:      configPrefs.preferred_formats ?? [...DEFAULT_PREFERRED_FORMATS],
+    minBitrate:            configPrefs.min_bitrate ?? 256,
+    preferLossless:        configPrefs.prefer_lossless ?? true,
+    rejectLowQuality:      configPrefs.reject_low_quality ?? false,
+    rejectLossless:        configPrefs.reject_lossless ?? false,
+    maxLosslessBitDepth:   configPrefs.max_lossless_bit_depth ?? 0,
+    maxLosslessSampleRate: configPrefs.max_lossless_sample_rate ?? 0,
+    rejectHighResLossless: configPrefs.reject_high_res_lossless ?? false,
   };
 }

--- a/server/src/types/slskd.ts
+++ b/server/src/types/slskd.ts
@@ -30,12 +30,15 @@ export interface QualityInfo {
  * User preferences for audio quality filtering and scoring
  */
 export interface QualityPreferences {
-  enabled:          boolean;
-  preferredFormats: string[];
-  minBitrate:       number;
-  preferLossless:   boolean;
-  rejectLowQuality: boolean;
-  rejectLossless:   boolean;
+  enabled:               boolean;
+  preferredFormats:      string[];
+  minBitrate:            number;
+  preferLossless:        boolean;
+  rejectLowQuality:      boolean;
+  rejectLossless:        boolean;
+  maxLosslessBitDepth:   number;   // 0 = unlimited
+  maxLosslessSampleRate: number;   // 0 = unlimited (Hz)
+  rejectHighResLossless: boolean;
 }
 
 /**

--- a/server/src/utils/audioQuality.test.ts
+++ b/server/src/utils/audioQuality.test.ts
@@ -10,6 +10,7 @@ import {
   extractQualityInfo,
   calculateQualityScore,
   shouldRejectFile,
+  exceedsLosslessCap,
   getDominantQualityInfo,
   calculateAverageQualityScore,
 } from './audioQuality';
@@ -178,12 +179,15 @@ describe('audioQuality utilities', () => {
 
   describe('calculateQualityScore', () => {
     const defaultPreferences: QualityPreferences = {
-      enabled:          true,
-      preferredFormats: ['flac', 'wav', 'alac', 'mp3'],
-      minBitrate:       256,
-      preferLossless:   true,
-      rejectLowQuality: false,
-      rejectLossless:   false,
+      enabled:               true,
+      preferredFormats:      ['flac', 'wav', 'alac', 'mp3'],
+      minBitrate:            256,
+      preferLossless:        true,
+      rejectLowQuality:      false,
+      rejectLossless:        false,
+      maxLosslessBitDepth:   0,
+      maxLosslessSampleRate: 0,
+      rejectHighResLossless: false,
     };
 
     it('returns 0 when preferences are disabled', () => {
@@ -242,16 +246,40 @@ describe('audioQuality utilities', () => {
       // Base 50 + preferred format 100 - below bitrate 200 = -50
       expect(score).toBe(-50);
     });
+
+    it('penalizes over-cap lossless below a compliant lossless file', () => {
+      const capPrefs = {
+        ...defaultPreferences,
+        maxLosslessBitDepth:   16,
+        maxLosslessSampleRate: 44100,
+      };
+      const compliant: QualityInfo = {
+        format: 'flac', bitRate: 1411, bitDepth: 16, sampleRate: 44100, tier: 'lossless'
+      };
+      const overCap: QualityInfo = {
+        format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 96000, tier: 'lossless'
+      };
+
+      const compliantScore = calculateQualityScore(compliant, capPrefs);
+      const overCapScore = calculateQualityScore(overCap, capPrefs);
+
+      // Over-cap loses the 500 penalty regardless of the reject toggle
+      expect(overCapScore).toBe(compliantScore - 500);
+      expect(overCapScore).toBeLessThan(compliantScore);
+    });
   });
 
   describe('shouldRejectFile', () => {
     const preferences: QualityPreferences = {
-      enabled:          true,
-      preferredFormats: ['flac', 'mp3'],
-      minBitrate:       256,
-      preferLossless:   true,
-      rejectLowQuality: true,
-      rejectLossless:   false,
+      enabled:               true,
+      preferredFormats:      ['flac', 'mp3'],
+      minBitrate:            256,
+      preferLossless:        true,
+      rejectLowQuality:      true,
+      rejectLossless:        false,
+      maxLosslessBitDepth:   0,
+      maxLosslessSampleRate: 0,
+      rejectHighResLossless: false,
     };
 
     it('returns false when preferences are disabled', () => {
@@ -323,6 +351,115 @@ describe('audioQuality utilities', () => {
       };
 
       expect(shouldRejectFile(info, preferences)).toBe(false);
+    });
+
+    describe('max lossless quality cap', () => {
+      // 16-bit / 44.1 kHz cap with the hard-cutoff toggle enabled
+      const capPrefs: QualityPreferences = {
+        ...preferences,
+        maxLosslessBitDepth:   16,
+        maxLosslessSampleRate: 44100,
+        rejectHighResLossless: true,
+      };
+
+      it('rejects over-cap lossless when rejectHighResLossless is true', () => {
+        const info: QualityInfo = {
+          format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 96000, tier: 'lossless'
+        };
+
+        expect(shouldRejectFile(info, capPrefs)).toBe(true);
+      });
+
+      it('accepts at-or-under-cap lossless', () => {
+        const info: QualityInfo = {
+          format: 'flac', bitRate: 1411, bitDepth: 16, sampleRate: 44100, tier: 'lossless'
+        };
+
+        expect(shouldRejectFile(info, capPrefs)).toBe(false);
+      });
+
+      it('does not reject over-cap lossless when toggle is off (deprioritize only)', () => {
+        const info: QualityInfo = {
+          format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 96000, tier: 'lossless'
+        };
+        const noToggle = { ...capPrefs, rejectHighResLossless: false };
+
+        expect(shouldRejectFile(info, noToggle)).toBe(false);
+      });
+
+      it('never rejects on unknown bit depth / sample rate', () => {
+        const info: QualityInfo = {
+          format: 'flac', bitRate: null, bitDepth: null, sampleRate: null, tier: 'lossless'
+        };
+
+        expect(shouldRejectFile(info, capPrefs)).toBe(false);
+      });
+
+      it('enforces the cap independently of rejectLowQuality', () => {
+        const info: QualityInfo = {
+          format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 96000, tier: 'lossless'
+        };
+        const noLowQuality = { ...capPrefs, rejectLowQuality: false };
+
+        expect(shouldRejectFile(info, noLowQuality)).toBe(true);
+      });
+    });
+  });
+
+  describe('exceedsLosslessCap', () => {
+    const capPrefs: QualityPreferences = {
+      enabled:               true,
+      preferredFormats:      ['flac'],
+      minBitrate:            256,
+      preferLossless:        true,
+      rejectLowQuality:      false,
+      rejectLossless:        false,
+      maxLosslessBitDepth:   16,
+      maxLosslessSampleRate: 44100,
+      rejectHighResLossless: true,
+    };
+
+    it('returns true when bit depth or sample rate exceeds the cap', () => {
+      const info: QualityInfo = {
+        format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 96000, tier: 'lossless'
+      };
+
+      expect(exceedsLosslessCap(info, capPrefs)).toBe(true);
+    });
+
+    it('returns false at the cap boundary', () => {
+      const info: QualityInfo = {
+        format: 'flac', bitRate: 1411, bitDepth: 16, sampleRate: 44100, tier: 'lossless'
+      };
+
+      expect(exceedsLosslessCap(info, capPrefs)).toBe(false);
+    });
+
+    it('returns false when metadata is unknown', () => {
+      const info: QualityInfo = {
+        format: 'flac', bitRate: null, bitDepth: null, sampleRate: null, tier: 'lossless'
+      };
+
+      expect(exceedsLosslessCap(info, capPrefs)).toBe(false);
+    });
+
+    it('returns false when caps are 0 (unlimited)', () => {
+      const info: QualityInfo = {
+        format: 'flac', bitRate: 2304, bitDepth: 24, sampleRate: 192000, tier: 'lossless'
+      };
+      const unlimited = {
+        ...capPrefs, maxLosslessBitDepth: 0, maxLosslessSampleRate: 0 
+      };
+
+      expect(exceedsLosslessCap(info, unlimited)).toBe(false);
+    });
+
+    it('returns false for lossy files regardless of caps', () => {
+      const info: QualityInfo = {
+        format: 'mp3', bitRate: 320, bitDepth: null, sampleRate: 48000, tier: 'high'
+      };
+
+      expect(exceedsLosslessCap(info, capPrefs)).toBe(false);
     });
   });
 
@@ -397,12 +534,15 @@ describe('audioQuality utilities', () => {
 
   describe('calculateAverageQualityScore', () => {
     const preferences: QualityPreferences = {
-      enabled:          true,
-      preferredFormats: ['flac', 'mp3'],
-      minBitrate:       256,
-      preferLossless:   true,
-      rejectLowQuality: false,
-      rejectLossless:   false,
+      enabled:               true,
+      preferredFormats:      ['flac', 'mp3'],
+      minBitrate:            256,
+      preferLossless:        true,
+      rejectLowQuality:      false,
+      rejectLossless:        false,
+      maxLosslessBitDepth:   0,
+      maxLosslessSampleRate: 0,
+      rejectHighResLossless: false,
     };
 
     it('returns 0 for empty file list', () => {

--- a/server/src/utils/audioQuality.ts
+++ b/server/src/utils/audioQuality.ts
@@ -14,6 +14,7 @@ import {
   LOW_QUALITY_BITRATE,
   QUALITY_SCORES,
   QUALITY_TIER_ORDER,
+  LOSSLESS_OVER_CAP_PENALTY,
 } from '@server/constants/slskd';
 
 /**
@@ -105,6 +106,30 @@ export function extractQualityInfo(file: SlskdFile): QualityInfo {
 }
 
 /**
+ * Determine whether a lossless file exceeds the configured maximum lossless
+ * quality cap (max bit depth and/or max sample rate). A cap of 0 means
+ * unlimited. Files with unknown (null) bit depth or sample rate are given the
+ * benefit of the doubt and never reported as exceeding the cap.
+ */
+export function exceedsLosslessCap(info: QualityInfo, preferences: QualityPreferences): boolean {
+  if (info.tier !== 'lossless') {
+    return false;
+  }
+
+  const { maxLosslessBitDepth, maxLosslessSampleRate } = preferences;
+
+  if (maxLosslessBitDepth > 0 && info.bitDepth !== null && info.bitDepth > maxLosslessBitDepth) {
+    return true;
+  }
+
+  if (maxLosslessSampleRate > 0 && info.sampleRate !== null && info.sampleRate > maxLosslessSampleRate) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Calculate a quality score for a file based on preferences
  */
 export function calculateQualityScore(info: QualityInfo, preferences: QualityPreferences): number {
@@ -122,6 +147,12 @@ export function calculateQualityScore(info: QualityInfo, preferences: QualityPre
   // Bonus for lossless when prefer_lossless is enabled
   if (preferences.preferLossless && info.tier === 'lossless') {
     score += 500;
+  }
+
+  // Penalize lossless files exceeding the max lossless quality cap so they rank
+  // below compliant files even when not hard-rejected (deprioritize behavior).
+  if (exceedsLosslessCap(info, preferences)) {
+    score -= LOSSLESS_OVER_CAP_PENALTY;
   }
 
   // Bonus/penalty based on bitrate relative to minBitrate
@@ -148,6 +179,12 @@ export function shouldRejectFile(info: QualityInfo, preferences: QualityPreferen
 
   // Reject lossless files if rejectLossless is enabled
   if (preferences.rejectLossless && info.tier === 'lossless') {
+    return true;
+  }
+
+  // Hard cutoff for lossless files exceeding the max lossless quality cap.
+  // Independent of rejectLowQuality so it applies on its own toggle.
+  if (preferences.rejectHighResLossless && exceedsLosslessCap(info, preferences)) {
     return true;
   }
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,4 +1,2 @@
-allowBuilds:
-  '@parcel/watcher': true
 onlyBuiltDependencies:
   - esbuild

--- a/ui/src/components/settings/SlskdForm.vue
+++ b/ui/src/components/settings/SlskdForm.vue
@@ -34,6 +34,29 @@ const selectionModeOptions = [
   { label: 'Auto', value: 'auto' },
 ];
 
+// Max lossless quality presets. bitDepth/sampleRate of 0 means unlimited.
+// 'custom' has no fixed values and reveals the manual bit depth / sample rate inputs.
+const LOSSLESS_PRESETS = [
+  {
+    label: 'Unlimited',                  value: 'unlimited', bitDepth: 0,  sampleRate: 0
+  },
+  {
+    label: 'CD (16-bit / 44.1 kHz)',     value: 'cd',        bitDepth: 16, sampleRate: 44100
+  },
+  {
+    label: 'Hi-Res (24-bit / 48 kHz)',   value: 'hires_48',  bitDepth: 24, sampleRate: 48000
+  },
+  {
+    label: 'Hi-Res (24-bit / 96 kHz)',   value: 'hires_96',  bitDepth: 24, sampleRate: 96000
+  },
+  {
+    label: 'Hi-Res (24-bit / 192 kHz)',  value: 'hires_192', bitDepth: 24, sampleRate: 192000
+  },
+  { label: 'Custom',                     value: 'custom' },
+] as const;
+
+const losslessPresetOptions = LOSSLESS_PRESETS.map(({ label, value }) => ({ label, value }));
+
 const FORMAT_SUGGESTIONS = ['flac', 'wav', 'alac', 'aiff', 'mp3', 'm4a', 'aac', 'ogg', 'opus', 'wma'];
 const EXCLUDE_TERM_SUGGESTIONS = ['live', 'remix', 'demo', 'cover', 'acoustic', 'instrumental', 'remaster', 'bootleg', 'karaoke', 'tribute'];
 const FALLBACK_QUERY_SUGGESTIONS = ['{artist}', '{album}', '{artist} {album}', '{artist} discography', '{artist} {album} {year}'];
@@ -67,12 +90,15 @@ const form = reactive<SlskdForm>({
       delay_between_retries_ms: 5000,
     },
     quality_preferences: {
-      enabled:            false,
-      preferred_formats:  ['flac', 'wav', 'alac', 'mp3', 'm4a', 'ogg'],
-      min_bitrate:        256,
-      prefer_lossless:    true,
-      reject_low_quality: false,
-      reject_lossless:    false,
+      enabled:                  false,
+      preferred_formats:        ['flac', 'wav', 'alac', 'mp3', 'm4a', 'ogg'],
+      min_bitrate:              256,
+      prefer_lossless:          true,
+      reject_low_quality:       false,
+      reject_lossless:          false,
+      max_lossless_bit_depth:   0,
+      max_lossless_sample_rate: 0,
+      reject_high_res_lossless: false,
     },
     completeness: {
       enabled:                true,
@@ -86,6 +112,19 @@ const form = reactive<SlskdForm>({
   },
   selection: { mode: 'manual', timeout_hours: 24 },
 });
+
+// Selected preset for the max lossless quality control. Derived from the stored
+// bit depth / sample rate; selecting a non-custom preset writes those values back.
+const losslessPreset = ref<string>('unlimited');
+
+function deriveLosslessPreset(): string {
+  const { max_lossless_bit_depth: bitDepth, max_lossless_sample_rate: sampleRate } = form.search.quality_preferences;
+  const match = LOSSLESS_PRESETS.find(
+    p => p.value !== 'custom' && p.bitDepth === bitDepth && p.sampleRate === sampleRate,
+  );
+
+  return match ? match.value : 'custom';
+}
 
 watch(
   () => props.settings,
@@ -102,6 +141,7 @@ watch(
 
     if (next.search && form.search) {
       Object.assign(form.search, next.search);
+      losslessPreset.value = deriveLosslessPreset();
     }
 
     if (next.selection && form.selection) {
@@ -110,6 +150,18 @@ watch(
   },
   { immediate: true }
 );
+
+watch(losslessPreset, (value) => {
+  const preset = LOSSLESS_PRESETS.find(p => p.value === value);
+
+  // 'custom' leaves the values untouched so the manual inputs can edit them.
+  if (preset && preset.value !== 'custom') {
+    form.search.quality_preferences.max_lossless_bit_depth = preset.bitDepth;
+    form.search.quality_preferences.max_lossless_sample_rate = preset.sampleRate;
+  }
+});
+
+const showCustomLosslessCaps = computed(() => losslessPreset.value === 'custom');
 
 const apiKeyConfigured = computed(() => props.settings?.api_key?.configured ?? false);
 
@@ -517,6 +569,68 @@ function searchFallbackQueries(event: { query: string }) {
             v-model="form.search.quality_preferences.reject_lossless"
             :disabled="loading || !form.search.quality_preferences.enabled"
           />
+        </div>
+
+        <div class="settings-form__field">
+          <label for="setting-slskd-max-lossless" class="settings-form__label">
+            Max Lossless Quality
+          </label>
+          <Select
+            id="setting-slskd-max-lossless"
+            v-model="losslessPreset"
+            :options="losslessPresetOptions"
+            option-label="label"
+            option-value="value"
+            :disabled="loading || !form.search.quality_preferences.enabled"
+            fluid
+          />
+          <span class="settings-form__help">
+            Cap the resolution of lossless downloads. Files with unknown bit depth /
+            sample rate are never rejected.
+          </span>
+        </div>
+
+        <div v-if="showCustomLosslessCaps" class="settings-form__field">
+          <label for="setting-slskd-max-bit-depth" class="settings-form__label">
+            Max Bit Depth
+          </label>
+          <InputNumber
+            id="setting-slskd-max-bit-depth"
+            v-model="form.search.quality_preferences.max_lossless_bit_depth"
+            :disabled="loading || !form.search.quality_preferences.enabled"
+            :min="0"
+            :max="32"
+          />
+          <span class="settings-form__help">0 = unlimited</span>
+        </div>
+
+        <div v-if="showCustomLosslessCaps" class="settings-form__field">
+          <label for="setting-slskd-max-sample-rate" class="settings-form__label">
+            Max Sample Rate (Hz)
+          </label>
+          <InputNumber
+            id="setting-slskd-max-sample-rate"
+            v-model="form.search.quality_preferences.max_lossless_sample_rate"
+            :disabled="loading || !form.search.quality_preferences.enabled"
+            :min="0"
+            :step="100"
+          />
+          <span class="settings-form__help">0 = unlimited</span>
+        </div>
+
+        <div class="settings-form__field">
+          <label for="setting-slskd-reject-high-res" class="settings-form__label">
+            Reject High-Res Lossless
+          </label>
+          <ToggleSwitch
+            id="setting-slskd-reject-high-res"
+            v-model="form.search.quality_preferences.reject_high_res_lossless"
+            :disabled="loading || !form.search.quality_preferences.enabled"
+          />
+          <span class="settings-form__help">
+            Hard-reject lossless files above the cap. When off, they are only
+            deprioritized.
+          </span>
         </div>
 
         <div class="settings-form__field settings-form__field--full">

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -81,12 +81,15 @@ export interface SlskdRetrySettings {
 }
 
 export interface SlskdQualitySettings {
-  enabled:            boolean;
-  preferred_formats:  string[];
-  min_bitrate:        number;
-  prefer_lossless:    boolean;
-  reject_low_quality: boolean;
-  reject_lossless:    boolean;
+  enabled:                  boolean;
+  preferred_formats:        string[];
+  min_bitrate:              number;
+  prefer_lossless:          boolean;
+  reject_low_quality:       boolean;
+  reject_lossless:          boolean;
+  max_lossless_bit_depth:   number;   // 0 = unlimited
+  max_lossless_sample_rate: number;   // 0 = unlimited (Hz)
+  reject_high_res_lossless: boolean;
 }
 
 export interface SlskdSelectionSettings {


### PR DESCRIPTION
Close #192 

This will add lossless quality preferences to the settings configuration. From the UI there will be a dropdown input with populated examples for lossless quality or a custom input. When unset (or `0` for bit depth and sample rate) there will be no limit. By default, any files that exceed the max quality will just be de-prioritized, there is a new setting that will reject those files instead.

For example:

```yaml
slskd:
  ...
  search:
    quality_preferences:
      enabled: true
      preferred_formats:
        - flac
      max_lossless_bit_depth: 16        # Max lossless bit depth (e.g. 16 = CD quality)
      max_lossless_sample_rate: 44100   # Max lossless sample rate in Hz (e.g. 44100 = CD quality)
      reject_high_res_lossless: true    # Hard reject lossless above the caps (vs just de-prioritize)
```

<details closed>
<summary>Quality pref with custom inputs</summary>

<img width="1281" height="1179" alt="quality-pref1" src="https://github.com/user-attachments/assets/32fec843-a4ae-4bb0-a1e1-8ec4fbf83afd" />

</details>

<details closed>
<summary>Quality pref dropdown with populated options</summary>

<img width="917" height="524" alt="quality-pref2" src="https://github.com/user-attachments/assets/fd71ec24-4a40-4f21-a06a-7a5d0cc7dd2d" />

</details>