### PR TITLE
feat(wishlist): remove duplicate items from wishlist on library sync

### DIFF
--- a/docs/src/guide/webhooks.md
+++ b/docs/src/guide/webhooks.md
@@ -9,6 +9,7 @@ DeepCrate can send HTTP webhooks when key events occur, letting you integrate wi
 | `download_completed` | An album or track finishes downloading via slskd |
 | `queue_approved` | A queue item is approved (moved to wishlist) |
 | `queue_rejected` | A queue item is rejected |
+| `wishlist_removed` | A wishlist item is removed because it already exists in your library (during a library sync) |
 
 ## Configuration
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -287,5 +287,6 @@ webhooks:
       - download_completed
       - queue_approved
       - queue_rejected
+      - wishlist_removed
     timeout_ms: 10000               # max: 30000
     retry: 2                        # max: 5

--- a/server/src/config/schemas.ts
+++ b/server/src/config/schemas.ts
@@ -261,8 +261,9 @@ const CatalogDiscoverySettingsSchema = z.object({
 ]));
 
 const LibraryDuplicateSettingsSchema = z.object({
-  enabled:     z.boolean(),
-  auto_reject: z.boolean().optional().default(false),
+  enabled:                     z.boolean(),
+  auto_reject:                 z.boolean().optional().default(false),
+  remove_wishlist_duplicates:  z.boolean().optional().default(true),
 }).superRefine((value) => {
   if (!value.enabled) {
     return;
@@ -294,6 +295,7 @@ const WebhookEventSchema = z.enum([
   'download_completed',
   'queue_approved',
   'queue_rejected',
+  'wishlist_removed',
 ]);
 
 const WebhookSchema = z.object({

--- a/server/src/jobs/librarySync.ts
+++ b/server/src/jobs/librarySync.ts
@@ -51,6 +51,17 @@ export async function librarySyncJob(): Promise<void> {
 
     logger.info(`Updated ${ updatedCount } queue items with library status`);
 
+    if (isJobCancelled(JOB_NAMES.LIBRARY_SYNC)) {
+      logger.info('Job cancelled before re-checking wishlist items');
+      throw new Error('Job cancelled');
+    }
+
+    const removed = await libraryService.recheckWishlistItems();
+
+    if (removed) {
+      logger.info(`Removed ${ removed.length } wishlist items already in library`);
+    }
+
     logger.info('Library sync job completed');
   } catch(error) {
     logger.error('Library sync job failed:', { error });

--- a/server/src/openapi/schemas.ts
+++ b/server/src/openapi/schemas.ts
@@ -170,6 +170,7 @@ const webhookEventSchema = z.enum([
   'download_completed',
   'queue_approved',
   'queue_rejected',
+  'wishlist_removed',
 ]);
 
 const webhookPayloadSchema = z.object({

--- a/server/src/services/LibraryService.test.ts
+++ b/server/src/services/LibraryService.test.ts
@@ -1,0 +1,114 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { Op } from '@sequelize/core';
+
+const {
+  mockWishlistFindAll,
+  mockWishlistDestroy,
+  mockLibraryFindAll,
+  mockGetConfig,
+  mockFireEvent,
+} = vi.hoisted(() => ({
+  mockWishlistFindAll: vi.fn(),
+  mockWishlistDestroy: vi.fn(),
+  mockLibraryFindAll:  vi.fn(),
+  mockGetConfig:       vi.fn(),
+  mockFireEvent:       vi.fn(),
+}));
+
+vi.mock('@server/models/WishlistItem', () => ({ default: { findAll: mockWishlistFindAll, destroy: mockWishlistDestroy } }));
+vi.mock('@server/models/LibraryAlbum', () => ({ default: { findAll: mockLibraryFindAll } }));
+vi.mock('@server/models/QueueItem', () => ({ default: { findAll: vi.fn() } }));
+vi.mock('@server/config/settings', () => ({ getConfig: mockGetConfig }));
+vi.mock('@server/config/logger', () => ({
+  default: {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  },
+}));
+vi.mock('@server/config/db', () => ({ withDbWrite: (fn: () => unknown) => fn() }));
+vi.mock('@server/services/WebhookService', () => ({ fireEvent: mockFireEvent }));
+
+import { LibraryService } from '@server/services/LibraryService';
+
+function makeWishlistItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id:     'wl-1',
+    artist: 'Artist A',
+    album:  'Album A',
+    mbid:   'mbid-a',
+    ...overrides,
+  };
+}
+
+// LibraryAlbum rows are matched by lowercase artist/name in checkBatch.
+function makeLibraryRow(artistLower: string, nameLower: string) {
+  return { artistLower, nameLower };
+}
+
+describe('LibraryService.recheckWishlistItems', () => {
+  let service: LibraryService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReturnValue({ library_duplicate: { enabled: true, remove_wishlist_duplicates: true } });
+    service = new LibraryService();
+  });
+
+  it('removes wishlist items found in the library and fires a webhook per removal', async() => {
+    const inLibrary = makeWishlistItem({
+      id: 'wl-1', artist: 'Artist A', album: 'Album A'
+    });
+    const notInLibrary = makeWishlistItem({
+      id: 'wl-2', artist: 'Artist B', album: 'Album B', mbid: 'mbid-b',
+    });
+
+    mockWishlistFindAll.mockResolvedValue([inLibrary, notInLibrary]);
+    // Only "Artist A / Album A" exists in the library.
+    mockLibraryFindAll.mockResolvedValue([makeLibraryRow('artist a', 'album a')]);
+
+    const removed = await service.recheckWishlistItems();
+
+    expect(removed).toHaveLength(1);
+    expect(removed?.[0].id).toBe('wl-1');
+    expect(mockWishlistDestroy).toHaveBeenCalledWith({ where: { id: { [Op.in]: ['wl-1'] } } });
+    expect(mockFireEvent).toHaveBeenCalledTimes(1);
+    expect(mockFireEvent).toHaveBeenCalledWith('wishlist_removed', {
+      artist: 'Artist A',
+      album:  'Album A',
+      mbid:   'mbid-a',
+    });
+  });
+
+  it('does nothing when remove_wishlist_duplicates is disabled', async() => {
+    mockGetConfig.mockReturnValue({ library_duplicate: { enabled: true, remove_wishlist_duplicates: false } });
+
+    const removed = await service.recheckWishlistItems();
+
+    expect(removed).toBeUndefined();
+    expect(mockWishlistFindAll).not.toHaveBeenCalled();
+    expect(mockWishlistDestroy).not.toHaveBeenCalled();
+    expect(mockFireEvent).not.toHaveBeenCalled();
+  });
+
+  it('removes nothing when no wishlist items match the library', async() => {
+    mockWishlistFindAll.mockResolvedValue([makeWishlistItem()]);
+    mockLibraryFindAll.mockResolvedValue([]);
+
+    const removed = await service.recheckWishlistItems();
+
+    expect(removed).toBeUndefined();
+    expect(mockWishlistDestroy).not.toHaveBeenCalled();
+    expect(mockFireEvent).not.toHaveBeenCalled();
+  });
+
+  it('ignores wishlist items with an empty album', async() => {
+    mockWishlistFindAll.mockResolvedValue([makeWishlistItem({ album: '   ' })]);
+
+    const removed = await service.recheckWishlistItems();
+
+    expect(removed).toBeUndefined();
+    expect(mockLibraryFindAll).not.toHaveBeenCalled();
+    expect(mockWishlistDestroy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/LibraryService.ts
+++ b/server/src/services/LibraryService.ts
@@ -2,9 +2,12 @@ import { Op } from '@sequelize/core';
 
 import logger from '@server/config/logger';
 import { getConfig } from '@server/config/settings';
+import { withDbWrite } from '@server/config/db';
+import { fireEvent } from '@server/services/WebhookService';
 import { SubsonicClient } from '@server/services/clients/SubsonicClient';
 import LibraryAlbum from '@server/models/LibraryAlbum';
 import QueueItem from '@server/models/QueueItem';
+import WishlistItem from '@server/models/WishlistItem';
 
 /**
  * Normalize a string for comparison: lowercase and trim whitespace.
@@ -250,5 +253,62 @@ export class LibraryService {
     logger.info(`Library recheck complete: updated ${ updatedCount } queue items`);
 
     return updatedCount;
+  }
+
+  /**
+   * Checks all wishlist items against the library and removes any that now
+   * exist in it (e.g. albums the user added manually). A `wishlist_removed`
+   * webhook event is sent for each item removed.
+   *
+   */
+  async recheckWishlistItems(): Promise<WishlistItem[] | undefined> {
+    const config = getConfig();
+    const removeEnabled = config.library_duplicate?.remove_wishlist_duplicates ?? true;
+
+    if (!removeEnabled) {
+      return;
+    }
+
+    const allItems = await WishlistItem.findAll();
+    const items = allItems.filter((item) => item.album && item.album.trim() !== '');
+
+    if (items.length === 0) {
+      return;
+    }
+
+    const itemsToCheck = items.map((item) => ({
+      artist: item.artist,
+      album:  item.album,
+    }));
+
+    const libraryMatches = await this.checkBatch(itemsToCheck);
+
+    // Items that already exist in the library.
+    const matched = items.filter((item) => {
+      const key = createLookupKey(item.artist, item.album);
+
+      return libraryMatches.get(key) ?? false;
+    });
+
+    if (matched.length === 0) {
+      return;
+    }
+
+    const matchedIds = matched.map((item) => item.id);
+
+    await withDbWrite(() => WishlistItem.destroy({ where: { id: { [Op.in]: matchedIds } } }));
+
+    for (const item of matched) {
+      fireEvent('wishlist_removed', {
+        artist: item.artist,
+        album:  item.album,
+        mbid:   item.mbid ?? undefined,
+      });
+      logger.info(`Removed wishlist item already in library: ${ item.artist } - ${ item.album }`);
+    }
+
+    logger.info(`Wishlist recheck complete: removed ${ matched.length } items already in library`);
+
+    return matched;
   }
 }

--- a/server/src/services/WebhookService.ts
+++ b/server/src/services/WebhookService.ts
@@ -94,6 +94,8 @@ export async function fireEvent(
     (w) => w.enabled && w.events.includes(event),
   );
 
+  logger.debug(`[webhook] firing ${ event } to ${ webhooks.length } webhook(s)`);
+
   if (webhooks.length === 0) {
     return;
   }

--- a/server/src/types/settings.ts
+++ b/server/src/types/settings.ts
@@ -209,7 +209,7 @@ const UpdateWebhooksRequestSchema = z.array(z.object({
   enabled:    z.boolean().optional(),
   url:        z.url(),
   secret:     z.string().optional(),
-  events:     z.array(z.enum(['download_completed', 'queue_approved', 'queue_rejected'])).min(1),
+  events:     z.array(z.enum(['download_completed', 'queue_approved', 'queue_rejected', 'wishlist_removed'])).min(1),
   timeout_ms: z.number().int().positive().max(30000)
     .optional(),
   retry:      z.number().int().min(0).max(5)

--- a/server/src/types/webhook.ts
+++ b/server/src/types/webhook.ts
@@ -1,7 +1,8 @@
 export type WebhookEvent =
   | 'download_completed'
   | 'queue_approved'
-  | 'queue_rejected';
+  | 'queue_rejected'
+  | 'wishlist_removed';
 
 export interface WebhookConfig {
   name:       string;

--- a/ui/src/components/settings/WebhooksForm.vue
+++ b/ui/src/components/settings/WebhooksForm.vue
@@ -43,6 +43,7 @@ const eventOptions = [
   { label: 'Download Completed', value: 'download_completed' as WebhookEvent },
   { label: 'Queue Approved',     value: 'queue_approved' as WebhookEvent },
   { label: 'Queue Rejected',     value: 'queue_rejected' as WebhookEvent },
+  { label: 'Wishlist Removed',   value: 'wishlist_removed' as WebhookEvent },
 ];
 
 watch(

--- a/ui/src/types/settings.ts
+++ b/ui/src/types/settings.ts
@@ -253,7 +253,8 @@ export interface ScoringFormData {
 export type WebhookEvent =
   | 'download_completed'
   | 'queue_approved'
-  | 'queue_rejected';
+  | 'queue_rejected'
+  | 'wishlist_removed';
 
 export interface WebhookConfig {
   name:       string;


### PR DESCRIPTION
Close #223 

This will remove any duplicate items from the wishlist that exist within the library catalog. The usual flow of adding items to the wishlist and subsequently downloading through deepcrate already removed those items, but in the case of a user downloading/adding an item manually to their library, the related wishlist item will now be removed automatically when the library sync job is ran.


> [!NOTE]
> A new webhook event is available that can be emitted when a wishlist item is removed during the library sync. `wishlist_removed` will need to be added to the list of `events` in the `webhooks` configuration:

```yaml
webhooks:
  - name: my-webhook
    enabled: true
    url: https://my.webhook/
    events:
      - download_completed
      - queue_approved
      - queue_rejected
      - wishlist_removed # <- add this
    timeout_ms: 10000
    retry: 0
 ```
A new configuration setting has been added `library_duplicate.remove_wishlist_duplicates` which is `true` by default now.

