### PR TITLE
chore: add primeui license key

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -63,7 +63,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: APP_VERSION=${{ steps.meta.outputs.version }}
+          build-args: |
+            APP_VERSION=${{ steps.meta.outputs.version }}
+            VITE_PRIMEUI_LICENSE=${{ secrets.VITE_PRIMEUI_LICENSE }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:24-alpine AS ui-builder
 WORKDIR /build
 ENV CI=true
 
+# If unset, the app just shows the "Invalid PrimeUI License" banner.
+ARG VITE_PRIMEUI_LICENSE
+ENV VITE_PRIMEUI_LICENSE=$VITE_PRIMEUI_LICENSE
+
 RUN corepack enable
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,1 @@
+VITE_PRIMEUI_LICENSE=no-longer-mit

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -25,7 +25,12 @@ useThemeStore(pinia).initialize();
 
 app.use(router);
 app.use(PrimeVue, {
-  theme: {
+  // PrimeVue 5 demands a signed license token client-side because it costs money to maintain
+  // "enterprise" component libraries, so it goes... for now. This key is injected
+  // at build time but is still visible in the shipped bundle, that's inherent to
+  // client-side license checks, not a leak. See ui/.env.example.
+  license: import.meta.env.VITE_PRIMEUI_LICENSE,
+  theme:   {
     preset:  DeepCratePreset,
     options: {
       darkModeSelector: '.dark',


### PR DESCRIPTION
Related #227 

PrimeVue [now requires](https://primeui.dev/nextchapter) a license key even for "free"/community level users. This will add the key into the build step.